### PR TITLE
fix: pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanopub"
+version= "1.0.0"
 description = "Python client for Nanopublications"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.12.4"
 license = { file = "LICENSE" }
 authors = [
     { name = "Robin Richardson", email = "r.richardson@esciencecenter.nl" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.12",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
the runner image for `ubuntu-latest` provides Python v3.12.3. Not sure how to deal with lower and higher version in this particular setup.