### PR TITLE
Fix `tuple` type annotation

### DIFF
--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -6,7 +6,7 @@ import re
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Tuple
 
 import rdflib
 import requests
@@ -193,7 +193,7 @@ class Nanopub:
             raise MalformedNanopubError("The nanopub is not valid, cannot sign it")
 
 
-    def publish(self) -> tuple(str, str, str | None):
+    def publish(self) -> Tuple[str, str, str | None]:
         """Publish a Nanopub object"""
         if not self.source_uri:
             self.sign()
@@ -209,7 +209,7 @@ class Nanopub:
             self._concept_uri = f"{self.source_uri}#{str(self._introduces_concept)}"
             log.info(f"Published concept to {self._concept_uri}")
             return self.source_uri, self._conf.use_server, self._concept_uri
-        
+
         return self.source_uri, self._conf.use_server
 
 


### PR DESCRIPTION
# Why

Current `main` won't work.

```
$ np
Traceback (most recent call last):
  File "/home/anatoly/.pyenv/versions/nanopub-py/bin/np", line 5, in <module>
    from nanopub.__main__ import cli
  File "/home/anatoly/projects/nanopub-py/nanopub/__init__.py", line 4, in <module>
    from .client import NanopubClient
  File "/home/anatoly/projects/nanopub-py/nanopub/client.py", line 22, in <module>
    from nanopub.nanopub import Nanopub
  File "/home/anatoly/projects/nanopub-py/nanopub/nanopub.py", line 24, in <module>
    class Nanopub:
  File "/home/anatoly/projects/nanopub-py/nanopub/nanopub.py", line 196, in Nanopub
    def publish(self) -> tuple(str, str, str | None):
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: tuple expected at most 1 argument, got 3
```

# What

- Since the library is said to work with Python 3.7+, `tuple` type is not subscriptable
- `Tuple` has to be explicitly imported from `typing`
- …and used with square brackets generic type parameterization syntax