### PR TITLE
Migrate ConjunctiveGraph to dataset; update skipped tests

### DIFF
--- a/docs/publishing/publish-nanopublications.md
+++ b/docs/publishing/publish-nanopublications.md
@@ -94,14 +94,14 @@ sub:pubinfo {
 You can also easily sign and publish a Nanopublication from a file.
 
 ```python
-from rdflib import ConjunctiveGraph
+from rdflib import Dataset
 from nanopub import Nanopub, NanopubConf, load_profile
 
 # 1. Create the config
 np_conf = NanopubConf(profile=load_profile(), use_test_server=True)
 
 # 2. Load the file in a RDFLib graph
-g = ConjunctiveGraph()
+g = Dataset()
 g.parse("nanopub.trig")
 
 # 3. Make a Nanopublication object with this assertion

--- a/nanopub/fdo/fdo_record.py
+++ b/nanopub/fdo/fdo_record.py
@@ -102,9 +102,6 @@ class FdoRecord:
 
         if isinstance(val, list):
             uris = [URIRef(v) for v in val]
-            print(len(uris))
-            for uri in uris:
-                print("DataRef URI:", uri)
             return uris[0] if len(uris) == 1 else uris
 
         return URIRef(val)
@@ -140,7 +137,6 @@ class FdoRecord:
         else:
             if existing != uri_ref:
                 self.tuples[FDOF.isMaterializedBy] = [existing, uri_ref]
-        print(self.tuples[FDOF.isMaterializedBy])
 
     def set_property(self, predicate: Union[str, URIRef], value: Union[str, URIRef, Literal]) -> None:
         pred = URIRef(predicate)

--- a/nanopub/sign_utils.py
+++ b/nanopub/sign_utils.py
@@ -4,7 +4,7 @@ import requests
 from Crypto.Hash import SHA256
 from Crypto.PublicKey import RSA
 from Crypto.Signature import PKCS1_v1_5
-from rdflib import BNode, ConjunctiveGraph, Graph, Literal, Namespace, URIRef
+from rdflib import BNode, Dataset, Graph, Literal, Namespace, URIRef
 
 from nanopub.definitions import NANOPUB_REGISTRY_URLS, NP_PREFIX, NP_TEMP_PREFIX
 from nanopub.namespaces import NPX
@@ -14,7 +14,7 @@ from nanopub.trustyuri.rdf.RdfPreprocessor import transform
 from nanopub.utils import MalformedNanopubError, extract_np_metadata, log
 
 
-def add_signature(g: ConjunctiveGraph, profile: Profile, dummy_namespace: Namespace, pubinfo_g: Graph) -> ConjunctiveGraph:
+def add_signature(g: Dataset, profile: Profile, dummy_namespace: Namespace, pubinfo_g: Graph) -> Dataset:
     """Implementation in python of the process to sign a nanopub with a RSA private key"""
     g.add((
         dummy_namespace["sig"],
@@ -78,7 +78,7 @@ def add_signature(g: ConjunctiveGraph, profile: Profile, dummy_namespace: Namesp
     return g
 
 
-def replace_trusty_in_graph(trusty_artefact: str, dummy_ns: str, graph: ConjunctiveGraph):
+def replace_trusty_in_graph(trusty_artefact: str, dummy_ns: str, graph: Dataset):
     """Replace all references to the dummy namespace by the Trusty artefact in a Graph"""
     if str(dummy_ns).startswith(NP_TEMP_PREFIX):
         # Replace with http://purl.org/np/ if the http://purl.org/nanopub/temp/
@@ -95,7 +95,7 @@ def replace_trusty_in_graph(trusty_artefact: str, dummy_ns: str, graph: Conjunct
     bnodemap: dict = {}
     for s, p, o, c in graph.quads():
         if c:
-            g = c.identifier
+            g = c
         else:
             raise Exception("Found a nquads without graph when replacing dummy URIs with trusty URIs. Something went wrong.")
         # new_g = Graph(identifier=str(transform(g, trusty_artefact, dummy_ns, bnodemap)))
@@ -113,7 +113,7 @@ def replace_trusty_in_graph(trusty_artefact: str, dummy_ns: str, graph: Conjunct
     return graph
 
 
-def publish_graph(g: ConjunctiveGraph, use_server: str = NANOPUB_REGISTRY_URLS[0]) -> bool:
+def publish_graph(g: Dataset, use_server: str = NANOPUB_REGISTRY_URLS[0]) -> bool:
     """Publish a signed nanopub to the given nanopub server.
     """
     log.info(f"Publishing to the nanopub server {use_server}")
@@ -125,8 +125,10 @@ def publish_graph(g: ConjunctiveGraph, use_server: str = NANOPUB_REGISTRY_URLS[0
     return True
 
 
-def verify_trusty(g: ConjunctiveGraph, source_uri: str, source_namespace: Namespace) -> bool:
+def verify_trusty(g: Dataset, source_uri: str, source_namespace: Namespace) -> bool:
     """Verify Trusty URI in a nanopub Graph"""
+    if not source_uri:
+        raise ValueError("source_uri must not be None")
     source_trusty = source_uri.split('/')[-1]
     quads = RdfUtils.get_quads(g)
     expected_trusty = RdfHasher.make_hash(
@@ -140,7 +142,7 @@ def verify_trusty(g: ConjunctiveGraph, source_uri: str, source_namespace: Namesp
         return True
 
 
-def verify_signature(g: ConjunctiveGraph, source_namespace: Namespace) -> bool:
+def verify_signature(g: Dataset, source_namespace: Namespace) -> bool:
     """Verify RSA signature in a nanopub Graph"""
     # Get signature and public key from the triples
     np_sig = extract_np_metadata(g)

--- a/nanopub/templates/nanopub_update.py
+++ b/nanopub/templates/nanopub_update.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Union
 
-from rdflib import ConjunctiveGraph, Graph, URIRef
+from rdflib import Dataset, Graph, URIRef
 
 from nanopub.namespaces import NPX
 from nanopub.nanopub import Nanopub
@@ -34,7 +34,7 @@ class NanopubUpdate(Nanopub):
         assertion: Graph = Graph(),
         provenance: Graph = Graph(),
         pubinfo: Graph = Graph(),
-        rdf: Union[ConjunctiveGraph, Path] = None,
+        rdf: Union[Dataset, Path] = None,
     ) -> None:
         conf = deepcopy(conf)
         conf.add_prov_generated_time = True

--- a/nanopub/trustyuri/rdf/RdfModule.py
+++ b/nanopub/trustyuri/rdf/RdfModule.py
@@ -1,4 +1,4 @@
-from rdflib.graph import ConjunctiveGraph
+from rdflib.graph import Dataset
 
 from nanopub.trustyuri.rdf import RdfHasher, RdfUtils
 from nanopub.trustyuri.TrustyUriModule import TrustyUriModule
@@ -9,7 +9,7 @@ class RdfModule(TrustyUriModule):
         return "RA"
     def has_correct_hash(self, resource):
         f = RdfUtils.get_format(resource.get_filename())
-        cg = ConjunctiveGraph()
+        cg = Dataset()
         cg.parse(data=resource.get_content(), format=f)
         quads = RdfUtils.get_quads(cg)
         h = RdfHasher.make_hash(quads, resource.get_hashstr())

--- a/nanopub/trustyuri/rdf/RdfTransformer.py
+++ b/nanopub/trustyuri/rdf/RdfTransformer.py
@@ -9,7 +9,7 @@ def transform_to_file(conjgraph, baseuri, outdir, filename):
     quads = RdfPreprocessor.preprocess(quads, baseuri=baseuri)
     hashstr = RdfHasher.make_hash(quads)
     quads = HashAdder.addhash(quads, hashstr)
-    conjgraph = RdfUtils.get_conjunctivegraph(quads)
+    conjgraph = RdfUtils.get_dataset(quads)
     name = ""
     if (baseuri is not None) and re.match('.*/.*', str(baseuri)):
         name = re.sub(r'^.*[^A-Za-z0-9.\-_]([A-Za-z0-9.\-_]*)$', r'\1', str(baseuri)) + "."
@@ -24,7 +24,7 @@ def transform_to_string(conjgraph, baseuri):
     quads = RdfPreprocessor.preprocess(quads, baseuri=baseuri)
     hashstr = RdfHasher.make_hash(quads)
     quads = HashAdder.addhash(quads, hashstr)
-    conjgraph = RdfUtils.get_conjunctivegraph(quads)
+    conjgraph = RdfUtils.get_dataset(quads)
     return conjgraph.serialize(format='trix')
 
 
@@ -33,4 +33,4 @@ def transform(conjgraph, baseuri):
     quads = RdfPreprocessor.preprocess(quads, baseuri=baseuri)
     hashstr = RdfHasher.make_hash(quads)
     quads = HashAdder.addhash(quads, hashstr)
-    return RdfUtils.get_conjunctivegraph(quads)
+    return RdfUtils.get_dataset(quads)

--- a/nanopub/trustyuri/rdf/RdfUtils.py
+++ b/nanopub/trustyuri/rdf/RdfUtils.py
@@ -1,6 +1,6 @@
 import re
 
-from rdflib.graph import ConjunctiveGraph, Graph
+from rdflib.graph import Dataset, Graph
 from rdflib.term import BNode, URIRef
 from rdflib.util import guess_format
 
@@ -78,10 +78,9 @@ def expand_baseuri(baseuri):
     return s
 
 
-def get_quads(conjunctivegraph):
+def get_quads(dataset):
     quads = []
-    for s, p, o, c in conjunctivegraph.quads((None, None, None)):
-        g = c.identifier
+    for s, p, o, g in dataset.quads((None, None, None, None)):
         if not isinstance(g, URIRef):
             g = None
         quads.append((g, s, p, o))
@@ -89,8 +88,8 @@ def get_quads(conjunctivegraph):
     return quads
 
 
-def get_conjunctivegraph(quads):
-    cg = ConjunctiveGraph()
+def get_dataset(quads):
+    cg = Dataset()
 #     for (c, s, p, o) in quads:
 #         cg.default_context = Graph(store=cg.store, identifier=c)
 #         cg.add((s, p, o))

--- a/nanopub/trustyuri/rdf/TransformRdf.py
+++ b/nanopub/trustyuri/rdf/TransformRdf.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-from rdflib.graph import ConjunctiveGraph
+from rdflib.graph import Dataset
 from rdflib.term import URIRef
 
 from nanopub.trustyuri.rdf import RdfTransformer, RdfUtils
@@ -14,7 +14,7 @@ def transform(args):
 
     with open(filename) as f:
         rdfFormat = RdfUtils.get_format(filename)
-        cg = ConjunctiveGraph()
+        cg = Dataset()
         cg.parse(data=f.read(), format=rdfFormat)
         baseuri = URIRef(baseuristr)
         outdir = os.path.abspath(os.path.join(str(filename), os.pardir))

--- a/nanopub/utils.py
+++ b/nanopub/utils.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
-from rdflib import ConjunctiveGraph, Namespace, URIRef
+from rdflib import Dataset, Namespace, URIRef
 
 from nanopub.definitions import DUMMY_NAMESPACE, DUMMY_URI
 
@@ -36,7 +36,7 @@ class NanopubMetadata:
     dict = asdict
 
 
-def extract_np_metadata(g: ConjunctiveGraph) -> NanopubMetadata:
+def extract_np_metadata(g: Dataset) -> NanopubMetadata:
     """Extract a nanopub URI, namespace and head/assertion/prov/pubinfo contexts from a Graph"""
     get_np_query = """prefix np: <http://www.nanopub.org/nschema#>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,4 +147,9 @@ no_implicit_optional = false
 [tool.pytest.ini_options]
 markers = [
     "no_rsa_key: mark a test as a test only run when there is no nanopub RSA key setup.",
+    "network: mark a test that requires network access.",
 ]
+filterwarnings = [
+    "ignore:.*ConjunctiveGraph is deprecated.*:DeprecationWarning" # rdflib warning from the parsers, already using Dataset in our own code, see also: https://github.com/RDFLib/rdflib/issues/3064
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def pytest_configure(config):
 
 skip_if_nanopub_server_unavailable = (
     pytest.mark.skipif(
-        requests.get(TEST_NANOPUB_QUERY_URL).status_code != 200,
+        requests.get(TEST_NANOPUB_QUERY_URL + 'RAkYh4UPJryajbtIDbLG-Bfd6A4JD2SbU9bmZdvaEdFRY/fdo-text-search?query=test').status_code != 200,
         reason='Nanopub server is unavailable'
     )
 )

--- a/tests/test_fdo_op_validate_integration.py
+++ b/tests/test_fdo_op_validate_integration.py
@@ -12,7 +12,6 @@ def test_validate_fdo_records(identifier):
     assert fdo_record is not None
 
     validation_result = validate_fdo_record(fdo_record)
-    print(f"Validation result for {identifier}: {validation_result}")
 
     assert validation_result.is_valid is True
     assert validation_result.errors == []

--- a/tests/test_fdo_op_validate_unit.py
+++ b/tests/test_fdo_op_validate_unit.py
@@ -79,7 +79,6 @@ def test_validate_fdo_record_success(mock_get, mock_resolve, valid_fdo_record):
     mock_resolve.return_value = None
 
     def mock_requests_get(url, *args, **kwargs):
-        print(f"[MOCK REQUEST] GET {url}")
         if "hdl.handle.net/api/handles/21.T11966/996c38676da9ee56f8ab" in url:
             return MagicMock(status_code=200, json=lambda: HANDLE_METADATA)
         elif "example.org/schema/fdo.json" in url:
@@ -90,7 +89,6 @@ def test_validate_fdo_record_success(mock_get, mock_resolve, valid_fdo_record):
     mock_get.side_effect = mock_requests_get
 
     result = validate_fdo_record(valid_fdo_record)
-    print("Validation result:", result)
 
     assert result.is_valid is True
 
@@ -165,7 +163,6 @@ def test_valid_fdo_from_nanopub_network(mock_resolve, mock_get):
     record = FdoRecord(assertion=record_graph)
     result = validate_fdo_record(record)
 
-    print("Validation result (valid nanopub):", result)
     assert result.is_valid is True
     assert result.errors == []
 
@@ -209,6 +206,5 @@ def test_invalid_fdo_from_nanopub_network(mock_resolve, mock_get):
     record = FdoRecord(assertion=record_graph)
     result = validate_fdo_record(record)
 
-    print("Validation result (invalid nanopub):", result)
     assert result.is_valid is False
     assert any("predicate" in e.lower() for e in result.errors)

--- a/tests/test_sign_utils.py
+++ b/tests/test_sign_utils.py
@@ -23,12 +23,6 @@ def test_nanopub_sign():
     )
     java_np = java_wrap.sign(np)
 
-    signed_g = add_signature(
-        np.rdf,
-        profile_test,
-        DUMMY_NAMESPACE,
-        np.pubinfo
-    )
-    np.update_from_signed(signed_g)
+    np.sign()
     assert np.source_uri == expected_np_uri
     assert np.source_uri == java_np

--- a/tests/test_testsuite.py
+++ b/tests/test_testsuite.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from rdflib import ConjunctiveGraph
+from rdflib import Dataset
 
 from nanopub import Nanopub
 from nanopub.utils import MalformedNanopubError
@@ -17,7 +17,7 @@ def test_testsuite_valid_plain():
         if "/signed." in str(test_file):
             continue
 
-        np_g = ConjunctiveGraph()
+        np_g = Dataset()
         if str(test_file).endswith(".xml"):
             np_g.parse(test_file, format="trix")
         else:
@@ -80,7 +80,7 @@ def test_testsuite_sign_valid():
 
     for test_file in test_files:
         print(f'✒️ Testing signing valid nanopub: {test_file}')
-        np_g = ConjunctiveGraph()
+        np_g = Dataset()
         if test_file.endswith(".xml"):
             np_g.parse(test_file, format="trix")
         else:


### PR DESCRIPTION
This PR: 
- replaces uses of ConjunctiveGraph with Dataset as the former is deprecated
- update (some) tests which were previously skipped
- ignore ConjunctiveGraph deprecation warnings coming from dependencies