### PR TITLE
Fix call Dataset.quads() with required argument

### DIFF
--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -575,7 +575,7 @@ class Nanopub:
         Furthermore, the URI the nanopub is published to is not known ahead of time.
         """
         bnode_map: dict = {}
-        for s, p, o, c in g.quads():
+        for s, p, o, c in g.quads(None):
             if isinstance(s, BNode):
                 g.remove((s, p, o, c))
                 if str(s) not in bnode_map:

--- a/nanopub/sign_utils.py
+++ b/nanopub/sign_utils.py
@@ -93,7 +93,7 @@ def replace_trusty_in_graph(trusty_artefact: str, dummy_ns: str, graph: Dataset)
 
     # Iterate quads in the graph, and replace by the transformed value
     bnodemap: dict = {}
-    for s, p, o, c in graph.quads():
+    for s, p, o, c in graph.quads(None):
         if c:
             g = c
         else:


### PR DESCRIPTION
Leftover from ConjunctiveGraph to Dataset migration; this should fix CI errors.