### PR TITLE
Fix client tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ no_implicit_optional = false
 markers = [
     "no_rsa_key: mark a test as a test only run when there is no nanopub RSA key setup.",
     "network: mark a test that requires network access.",
+    "flaky: mark test as flaky to rerun it on failure",
 ]
 filterwarnings = [
     "ignore:.*ConjunctiveGraph is deprecated.*:DeprecationWarning" # rdflib warning from the parsers, already using Dataset in our own code, see also: https://github.com/RDFLib/rdflib/issues/3064

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -134,43 +134,49 @@ class TestNanopubClient:
 
     # TODO: find retracted in the new nanopub server to fix those tests
 
-    # @pytest.mark.flaky(max_runs=10)
-    # @skip_if_nanopub_server_unavailable
-    # def test_find_things_filter_retracted(self):
-    #     filtered_results = list(client.find_things(type='http://purl.org/net/p-plan#Plan',
-    #                                                filter_retracted=True))
-    #     assert len(filtered_results) > 0
-    #     all_results = list(client.find_things(type='http://purl.org/net/p-plan#Plan',
-    #                                           filter_retracted=False))
-    #     assert len(all_results) > 0
-    #     # The filtered results should be a smaller subset of all the results, assuming that some of
-    #     # the results are retracted nanopublications.
-    #     assert len(all_results) > len(filtered_results)
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_things_filter_retracted(self):
+        filtered_results = list(
+            client.find_things(
+                type="http://purl.org/net/p-plan#Plan",
+                filter_retracted=True,
+                searchterm="WF_protocol3",
+            )
+        )
+        assert len(filtered_results) > 0
+        all_results = list(
+            client.find_things(
+                type="http://purl.org/net/p-plan#Plan",
+                filter_retracted=False,
+                searchterm="WF_protocol3",
+            )
+        )
+        assert len(all_results) > 0
+        # The filtered results should be a smaller subset of all the results, assuming that some of
+        # the results are retracted nanopublications.
+        assert len(all_results) > len(filtered_results)
 
-    # @pytest.mark.flaky(max_runs=10)
-    # @skip_if_nanopub_server_unavailable
-    # def test_find_retractions_of(self):
-    #     uri = 'http://purl.org/np/RAnksi2yDP7jpe7F6BwWCpMOmzBEcUImkAKUeKEY_2Yus'
-    #     results = client.find_retractions_of(uri, valid_only=False)
-    #     expected_uris = [
-    #         'http://purl.org/np/RAYhe0XddJhBsJvVt0h_aq16p6f94ymc2wS-q2BAgnPVY',
-    #         'http://purl.org/np/RACdYpR-6DZnT6JkEr1ItoYYXMAILjOhDqDZsMVO8EBZI'
-    #     ]
-    #     for expected_uri in expected_uris:
-    #         assert expected_uri in results
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_retractions_of(self):
+        uri = 'https://w3id.org/np/RAjwjgKTAHVVrdP0DCftOEbqi1FL-YPuf0r6xhwNgzDcU'
+        results = client.find_retractions_of(uri, valid_only=False)
+        expected_uri = 'https://w3id.org/np/RAuQdjy3pQhhPyda0hd1XXH4xH-XZ5Df3bW5RYCxxxK_U'
+        assert expected_uri in results
 
-
-    # @pytest.mark.flaky(max_runs=10)
-    # @skip_if_nanopub_server_unavailable
-    # def test_find_retractions_of_valid_only(self):
-    #     uri = 'http://purl.org/np/RAnksi2yDP7jpe7F6BwWCpMOmzBEcUImkAKUeKEY_2Yus'
-    #     results = client.find_retractions_of(uri, valid_only=True)
-    #     expected_uri = 'http://purl.org/np/RAYhe0XddJhBsJvVt0h_aq16p6f94ymc2wS-q2BAgnPVY'
-    #     assert expected_uri in results
-    #     # This is a nanopublication that is signed with a different public key than the nanopub
-    #     # it retracts, so it is not valid and should not be returned.
-    #     unexpected_uri = 'http://purl.org/np/RACdYpR-6DZnT6JkEr1ItoYYXMAILjOhDqDZsMVO8EBZI'
-    #     assert unexpected_uri not in results
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_retractions_of_valid_only(self):
+        uri = 'https://w3id.org/np/RAjwjgKTAHVVrdP0DCftOEbqi1FL-YPuf0r6xhwNgzDcU'
+        results = client.find_retractions_of(uri, valid_only=True)
+        expected_uri = 'https://w3id.org/np/RAuQdjy3pQhhPyda0hd1XXH4xH-XZ5Df3bW5RYCxxxK_U'
+        assert expected_uri in results
+        # This is a nanopublication that is signed with a different public key than the nanopub
+        # it retracts, so it is not valid and should not be returned.
+        # TODO: re-enable this test when we have a non-valid retraction to check
+        # unexpected_uri = 'http://purl.org/np/RACdYpR-6DZnT6JkEr1ItoYYXMAILjOhDqDZsMVO8EBZI'
+        # assert unexpected_uri not in results
 
     @pytest.mark.parametrize(
         "test_input,expected",


### PR DESCRIPTION
This PR fixes some additional client tests that were previously skipped. Also adding a custom mark for pytest  that was missing and triggering warnings.