### PR TITLE
fix: adding genrated pubinfo time by default

### DIFF
--- a/nanopub/nanopub_conf.py
+++ b/nanopub/nanopub_conf.py
@@ -28,7 +28,7 @@ class NanopubConf:
     use_server: str = NANOPUB_REGISTRY_URLS[0]
 
     add_prov_generated_time: bool = False
-    add_pubinfo_generated_time: bool = False
+    add_pubinfo_generated_time: bool = True
 
     attribute_assertion_to_profile: bool = False
     attribute_publication_to_profile: bool = False


### PR DESCRIPTION
This is a PR which addresses the missing generated time info string. See the discussion in https://github.com/Nanopublication/nanopub-py/issues/219. It turns out, that only a default setting needs to be changed.

I argue in favour of changing this default: After all, _all_ nanopubs ought to have this one particular string.