### PR TITLE
feat: cli retract

### DIFF
--- a/nanopub/__main__.py
+++ b/nanopub/__main__.py
@@ -12,7 +12,7 @@ import rdflib
 import typer
 from typer import Argument, Option
 
-from nanopub import Nanopub, NanopubClaim, NanopubConf, load_profile
+from nanopub import Nanopub, NanopubClaim, NanopubConf, NanopubRetract, load_profile
 from nanopub._version import __version__
 from nanopub.definitions import DEFAULT_PROFILE_PATH, USER_CONFIG_DIR
 from nanopub.profile import Profile, ProfileError, generate_keyfiles
@@ -105,6 +105,31 @@ def publish(
     np = Nanopub(conf=config, rdf=filepath)
     np.publish()
     print(f" 📬️ Nanopub published at \033[1m{np.source_uri}\033[0m")
+
+
+@cli.command(help='Retract  a Nanopublication')
+def retract(
+    uri: Annotated[
+        str,
+        Argument(help='URI of the nanopublication to retract.'),
+    ],
+    test: bool = typer.Option(False, help="Publish to the test server"),
+    force: bool = typer.Option(
+        False,
+        help=(
+            "Force retraction even if the publication was signed with a different public key"
+        ),
+    ),
+):
+    if test:
+        print(" 🧪 Publishing to the test server")
+    config = NanopubConf(
+        profile=load_profile(),
+        use_test_server=test,
+    )
+    np = NanopubRetract(conf=config, uri=uri, force=force)
+    np.publish()
+    print(f" 📬️ Retraction nanopub published at \033[1m{np.source_uri}\033[0m")
 
 
 

--- a/nanopub/nanopub_conf.py
+++ b/nanopub/nanopub_conf.py
@@ -28,7 +28,7 @@ class NanopubConf:
     use_server: str = NANOPUB_REGISTRY_URLS[0]
 
     add_prov_generated_time: bool = False
-    add_pubinfo_generated_time: bool = False
+    add_pubinfo_generated_time: bool = True
 
     attribute_assertion_to_profile: bool = False
     attribute_publication_to_profile: bool = False


### PR DESCRIPTION
This PR adds a CLI option "retract" based upon the retraction template.

Whilst the template offers a programmatic approach for users of the library, the command line option is important for users of the CLI tool `np` as publishing signs with "their" public key which at the same time is necessary to correct mistakes.

https://w3id.org/np/RAUQJFvCrjukXQQcq_ERYl082JrlsYxJG1ogok8K5ueT8 is demonstrating its working.

The PR comes without a test. A test can be provided too.

Note, that this PR is derived from the branch for https://github.com/Nanopublication/nanopub-py/pull/220 as only nanopubs with a time stamp are listed properly on nanodash and mirror servers.

Cheers
Chris