### PR TITLE
feat(fdo): import handle-record URL/handle values as IRIs

### DIFF
--- a/nanopub/fdo/fdo_nanopub.py
+++ b/nanopub/fdo/fdo_nanopub.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Optional
 
 import rdflib
@@ -10,6 +11,25 @@ from nanopub.fdo.fdo_record import FdoRecord
 from nanopub.fdo.utils import looks_like_handle, looks_like_url, handle_to_iri
 from nanopub.namespaces import HDL, FDOF, NPX, FDOC
 from nanopub.nanopub_conf import NanopubConf
+
+# Stricter than fdo.utils.looks_like_handle / looks_like_url: these mirror the
+# regexes used by nanopub-java's FdoUtils when deciding whether an imported
+# handle-record value is an IRI or a plain literal. Kept local so the loose
+# public helpers keep their current semantics for other callers.
+_IMPORT_URL_RE = re.compile(r"https?://\S+\.[a-z]{2,}.*")
+_IMPORT_HANDLE_RE = re.compile(r"\d\d\S*/+\S*")
+
+
+def _handle_value_to_rdf_object(value):
+    """Map a handle-record attribute value to an IRI if it looks like a URL or
+    bare handle, otherwise to a Literal. Mirrors nanopub-java's behavior in
+    ``FdoNanopubCreator.createFdoRecordFromHandleSystem``."""
+    if isinstance(value, str):
+        if _IMPORT_URL_RE.fullmatch(value):
+            return rdflib.URIRef(value)
+        if _IMPORT_HANDLE_RE.fullmatch(value):
+            return handle_to_iri(value)
+    return rdflib.Literal(value)
 
 
 def to_hdl_uri(value):
@@ -91,7 +111,8 @@ class FdoNanopub(Nanopub):
                 np.add_fdo_data_ref(ref)
 
         for attr_type, val in other_attributes:
-            np.add_attribute(attr_type, val)
+            predicate = to_hdl_uri(attr_type)
+            np.assertion.add((np.fdo_uri, predicate, _handle_value_to_rdf_object(val)))
 
         return np
 

--- a/tests/test_fdo_nanopub.py
+++ b/tests/test_fdo_nanopub.py
@@ -7,6 +7,7 @@ from rdflib import RDF, RDFS, DCTERMS
 from nanopub.constants import FDO_DATA_REF_HANDLE, FDO_PROFILE_HANDLE, FDO_DATA_REFS_HANDLE
 from nanopub.fdo.fdo_nanopub import FdoNanopub, to_hdl_uri
 from nanopub.fdo.fdo_record import FdoRecord
+from nanopub.fdo.utils import handle_to_iri
 from nanopub.namespaces import HDL, FDOF, NPX
 
 FAKE_HANDLE = "21.T11966/test"
@@ -132,6 +133,32 @@ def test_handle_to_nanopub_branches_minimal(monkeypatch, extra_entry):
     profile_uri = to_hdl_uri("21.T11966/profile")
     assert (np.fdo_uri, DCTERMS.conformsTo, profile_uri) in np.assertion
     assert_introduces_in_pubinfo(np)
+
+
+def test_handle_to_nanopub_imports_values_by_type(monkeypatch):
+    """URL-shaped and handle-shaped values become IRIs; plain strings stay literals."""
+    def fake_resolve_handle_metadata(handle):
+        return {
+            "values": [
+                {"type": "name", "data": {"value": "TestLabel"}},
+                {"type": "pid", "data": {"value": "https://doi.org/10.1234/abc"}},
+                {"type": "digitalObjectType", "data": {"value": "21.T11148/894b1e6cad57e921764e"}},
+                {"type": "catalogNumber", "data": {"value": "1983-0000001"}},
+                {"type": "topicCategory", "data": {"value": ""}},
+            ]
+        }
+
+    monkeypatch.setattr("nanopub.fdo.retrieve.resolve_handle_metadata", fake_resolve_handle_metadata)
+    np = FdoNanopub.handle_to_nanopub("21.T11966/test")
+
+    assert (np.fdo_uri, to_hdl_uri("pid"),
+            rdflib.URIRef("https://doi.org/10.1234/abc")) in np.assertion
+    assert (np.fdo_uri, to_hdl_uri("digitalObjectType"),
+            handle_to_iri("21.T11148/894b1e6cad57e921764e")) in np.assertion
+    assert (np.fdo_uri, to_hdl_uri("catalogNumber"),
+            rdflib.Literal("1983-0000001")) in np.assertion
+    assert (np.fdo_uri, to_hdl_uri("topicCategory"),
+            rdflib.Literal("")) in np.assertion
 
 
 def test_handle_to_nanopub_with_missing_value(monkeypatch):


### PR DESCRIPTION
## Summary

- When `FdoNanopub.handle_to_nanopub()` imports a handle record, attribute values that look like an http(s) URL or a bare handle (e.g. `21.T11148/...`) now become **IRI** objects in the assertion, not string literals. Plain text values (catalog numbers, labels, empty strings) continue as literals.
- Aligns the Python handle-import path with [nanopub-java's `FdoNanopubCreator.createFdoRecordFromHandleSystem`](https://github.com/Nanopublication/nanopub-java/blob/main/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java), producing structurally equivalent RDF for the same handle record.
- Detection regexes (`https?://\S+\.[a-z]{2,}.*` for URLs, `\d\d\S*/+\S*` for handles) are stricter than the loose public `looks_like_url` / `looks_like_handle` helpers and are kept private to the import loop. `add_attribute()` is untouched — callers passing arbitrary strings still get literals.

## Concrete impact

For the DataCite FDO `10.3535/ZJX-6N5-A5C`, eight attributes become IRIs where previously they were literals:

| Predicate | Value |
|---|---|
| `hdl:pid` | `https://doi.org/10.3535/ZJX-6N5-A5C` |
| `hdl:pidIssuer` | `https://ror.org/04wxnsj81` |
| `hdl:specimenHost` | `https://ror.org/01tv5y993` |
| `hdl:issuedForAgent` | `https://ror.org/02wddde16` |
| `hdl:digitalObjectType` | `https://doi.org/21.T11148/894b1e6cad57e921764e` |
| `hdl:fdoProfile` | `https://doi.org/21.T11148/d8de0819e144e4096645` |
| `hdl:fdoRecordLicenseId` | `https://spdx.org/licenses/CC0-1.0.json` |
| `hdl:normalisedPrimarySpecimenObjectId` | `https://w.jacq.org/W19830000001:C1V-JP9-1RL` |

## Test plan

- [x] New unit test `test_handle_to_nanopub_imports_values_by_type` covers all three branches (URL → IRI, bare handle → hdl: IRI, plain string → Literal, empty string → Literal)
- [x] Existing 32 FDO tests still pass
- [x] Full non-integration suite passes (400 tests)
- [x] Spot-check against real DOI `10.3535/ZJX-6N5-A5C` confirms 8 URL values are now IRI triples

🤖 Generated with [Claude Code](https://claude.com/claude-code)