### PR TITLE
Support `~~~ARTIFACTCODE~~~` placeholder in custom namespaces (#232)

### DIFF
--- a/nanopub/definitions.py
+++ b/nanopub/definitions.py
@@ -24,6 +24,11 @@ DUMMY_URI = DUMMY_NAMESPACE[""]
 NP_TEMP_PREFIX = "http://purl.org/nanopub/temp/"
 NP_PREFIX = "https://w3id.org/np/"
 
+# Placeholder that is substituted by the nanopub's trusty artifact code when
+# signing. It lets trusty codes be minted in custom namespaces rather than only
+# as sub-URIs of the nanopub itself (see issue #232).
+ARTIFACTCODE_PLACEHOLDER = "~~~ARTIFACTCODE~~~"
+
 MAX_NP_PER_INDEX = 1100
 MAX_TRIPLES_PER_NANOPUB = 1200
 

--- a/nanopub/trustyuri/rdf/RdfUtils.py
+++ b/nanopub/trustyuri/rdf/RdfUtils.py
@@ -4,7 +4,7 @@ from rdflib.graph import Dataset, Graph
 from rdflib.term import BNode, URIRef
 from rdflib.util import guess_format
 
-from nanopub.definitions import NP_PREFIX, NP_TEMP_PREFIX
+from nanopub.definitions import ARTIFACTCODE_PLACEHOLDER, NP_PREFIX, NP_TEMP_PREFIX
 from nanopub.trustyuri.TrustyUriUtils import is_trusty_uri, TRUSTY_ARTIFACT_RE
 
 
@@ -36,7 +36,19 @@ def get_trustyuri(resource, base_uri, hashstr, bnodemap):
         if get_str(resource).decode('utf-8') == np_uri:
             return str(f"{prefix}{hashstr}")
         if suffix is None and not get_str(resource).decode('utf-8') == get_str(base_uri).decode('utf-8'):
-            return str(resource)
+            # URI outside the nanopub's own namespace (e.g. a concept minted in a
+            # custom namespace). It may carry the artifact-code placeholder, or —
+            # when verifying an already-signed nanopub — this nanopub's trusty code.
+            # Substitute either with `hashstr` so it is part of the hash (and gets
+            # the real code substituted in when applying the trusty artifact).
+            # See issue #232.
+            res_str = str(resource).replace(ARTIFACTCODE_PLACEHOLDER, hashstr)
+            base_code = re.search(r'RA[A-Za-z0-9_\-]{40,}', str(base_uri))
+            if base_code:
+                # Only blank THIS nanopub's code; references to other trusty
+                # nanopubs (different codes) are left untouched.
+                res_str = res_str.replace(base_code.group(0), hashstr)
+            return res_str
         if suffix is None or suffix == "":
             return str(f"{prefix}{hashstr}")
         # External trusty URI or external reference — leave untouched

--- a/tests/test_sign_utils.py
+++ b/tests/test_sign_utils.py
@@ -7,7 +7,68 @@ from nanopub.definitions import NP_PREFIX, NP_TEMP_PREFIX
 from nanopub.namespaces import NPX
 from nanopub.sign_utils import add_signature
 from nanopub.trustyuri.rdf import RdfUtils
-from tests.conftest import profile_test
+from tests.conftest import profile_test, testsuite_conf
+
+
+ARTIFACTCODE_PLAIN_TRIG = """\
+@prefix this: <http://purl.org/nanopub/temp/1029384756/> .
+@prefix np: <http://www.nanopub.org/nschema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix npx: <http://purl.org/nanopub/x/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix ex: <https://example.org/ns/> .
+
+this:Head {
+  this: a np:Nanopublication;
+    np:hasAssertion this:assertion;
+    np:hasProvenance this:provenance;
+    np:hasPublicationInfo this:pubinfo .
+}
+
+this:assertion {
+  <https://example.org/ns/~~~ARTIFACTCODE~~~> a ex:Concept;
+    rdfs:label "a concept minted in a custom namespace" .
+}
+
+this:provenance {
+  this:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
+}
+
+this:pubinfo {
+  this: dct:created "2024-09-18T11:19:06.183Z"^^xsd:dateTime;
+    dct:creator orcid:0000-0002-1267-0234;
+    npx:introduces <https://example.org/ns/~~~ARTIFACTCODE~~~> .
+}
+"""
+
+
+def test_sign_artifactcode_placeholder_in_custom_namespace():
+    """Signing a nanopub that mints a concept in a custom namespace via the
+    ``~~~ARTIFACTCODE~~~`` placeholder gives that concept the same trusty code
+    as the nanopub itself, and the result is valid (see issue #232)."""
+    ds = Dataset()
+    ds.parse(data=ARTIFACTCODE_PLAIN_TRIG, format="trig")
+    np = Nanopub(conf=testsuite_conf, rdf=ds)
+    np.sign()
+
+    assert np.has_valid_signature
+    assert np.has_valid_trusty
+    assert np.is_valid
+
+    artifact_code = str(np.source_uri).removeprefix(NP_PREFIX)
+    assert re.fullmatch(r"RA[A-Za-z0-9\-_]{43}", artifact_code)
+
+    # The placeholder must be gone and the concept must carry the nanopub's code.
+    concept = URIRef(f"https://example.org/ns/{artifact_code}")
+    subjects = {s for s, _, _, _ in np.rdf.quads((None, None, None, None))}
+    objects = {o for _, _, o, _ in np.rdf.quads((None, None, None, None))}
+    assert concept in subjects
+    assert concept in objects  # still referenced by npx:introduces
+    for term in subjects | objects:
+        assert "~~~ARTIFACTCODE~~~" not in str(term)
 
 
 class TestVerifyTrusty:


### PR DESCRIPTION
Fixes #232.

## Problem

The nanopub testsuite added a `transform/artifactcode-1` case that signs a concept declared in a **custom namespace** using the `~~~ARTIFACTCODE~~~` placeholder:

```turtle
this:assertion {
  <https://example.org/ns/~~~ARTIFACTCODE~~~> a ex:Concept ; ...
}
```

The expected signed output gives that concept the nanopub's own trusty code (`ex:RAK4W62...`). Python's vendored trustyuri left any URI outside the nanopub's namespace untouched, so the placeholder survived signing, the hash didn't match, and `test_testsuite_sign_valid[rsa-key1/artifactcode-1.in.trig]` failed.

## Fix

Following the nanopub-java / trustyuri-java behaviour, `get_trustyuri` now handles URIs outside the nanopub's own namespace in three scenarios:

1. **Signing/hashing** — substitute `~~~ARTIFACTCODE~~~` with the hash placeholder so the concept is part of the hash.
2. **Applying the trusty artifact** — the same substitution writes the real trusty code into the custom namespace.
3. **Verification** — blank *this* nanopub's own trusty code back to the hash placeholder so the hash matches, while leaving references to *other* trusty nanopubs intact.

The produced trusty code is byte-identical to the Java reference output (`RAK4W62QQBgpEOgpDfW3bldxScwlIuWOmAkOL8xhSfxeQ`).

## Changes

- `nanopub/definitions.py` — add `ARTIFACTCODE_PLACEHOLDER` constant.
- `nanopub/trustyuri/rdf/RdfUtils.py` — substitute/blank the placeholder and code in the out-of-namespace branch.
- `tests/test_sign_utils.py` — add a network-independent regression test.

## Testing

All 425 tests pass (`uv run pytest`), including the previously failing testsuite case and the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)