### PR TITLE
test: move artifactcode signing test to TestSign and source from testsuite

### DIFF
--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -11,12 +11,13 @@ from nanopub import (
     NanopubConf,
     namespaces,
 )
+from nanopub.definitions import NP_PREFIX
 from nanopub.profile import ProfileError
 from nanopub.utils import MalformedNanopubError
 from tests.conftest import (
     default_conf,
     profile_test,
-    skip_if_nanopub_server_unavailable, testsuite,
+    skip_if_nanopub_server_unavailable, testsuite, testsuite_conf,
 )
 
 
@@ -466,6 +467,31 @@ class TestSign:
         np.sign()
         assert np.has_valid_signature
         assert expected_trusty in np.source_uri
+
+    def test_sign_artifactcode_placeholder_in_custom_namespace(self, testsuite):
+        """Signing a nanopub that mints a concept in a custom namespace via the
+        ``~~~ARTIFACTCODE~~~`` placeholder gives that concept the same trusty
+        code as the nanopub itself, and the result is valid (see issue #232)."""
+        tc = next(
+            tc for tc in testsuite.get_transform_cases("rsa-key1")
+            if tc.plain.name == "artifactcode-1.in.trig"
+        )
+        ds = Dataset()
+        ds.parse(data=tc.plain.read_text(), format="trig")
+        np = Nanopub(conf=testsuite_conf, rdf=ds)
+        np.sign()
+
+        assert np.has_valid_signature
+        assert np.has_valid_trusty
+        assert np.is_valid
+
+        # The concept minted in the custom namespace must carry the nanopub's
+        # trusty code, and the placeholder must be gone everywhere.
+        artifact_code = str(np.source_uri).removeprefix(NP_PREFIX)
+        concept = URIRef(f"https://example.org/ns/{artifact_code}")
+        terms = {term for quad in np.rdf.quads((None, None, None, None)) for term in quad}
+        assert concept in terms
+        assert all("~~~ARTIFACTCODE~~~" not in str(term) for term in terms)
 
     def test_nanopub_sign_bnode(self):
         expected_trusty = "RAcU1AR3dS0ricV5G_ENcpUCk40XuCvFW3tVFqxNEQzT4"

--- a/tests/test_sign_utils.py
+++ b/tests/test_sign_utils.py
@@ -7,68 +7,7 @@ from nanopub.definitions import NP_PREFIX, NP_TEMP_PREFIX
 from nanopub.namespaces import NPX
 from nanopub.sign_utils import add_signature
 from nanopub.trustyuri.rdf import RdfUtils
-from tests.conftest import profile_test, testsuite_conf
-
-
-ARTIFACTCODE_PLAIN_TRIG = """\
-@prefix this: <http://purl.org/nanopub/temp/1029384756/> .
-@prefix np: <http://www.nanopub.org/nschema#> .
-@prefix dct: <http://purl.org/dc/terms/> .
-@prefix npx: <http://purl.org/nanopub/x/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix orcid: <https://orcid.org/> .
-@prefix prov: <http://www.w3.org/ns/prov#> .
-@prefix ex: <https://example.org/ns/> .
-
-this:Head {
-  this: a np:Nanopublication;
-    np:hasAssertion this:assertion;
-    np:hasProvenance this:provenance;
-    np:hasPublicationInfo this:pubinfo .
-}
-
-this:assertion {
-  <https://example.org/ns/~~~ARTIFACTCODE~~~> a ex:Concept;
-    rdfs:label "a concept minted in a custom namespace" .
-}
-
-this:provenance {
-  this:assertion prov:wasAttributedTo orcid:0000-0002-1267-0234 .
-}
-
-this:pubinfo {
-  this: dct:created "2024-09-18T11:19:06.183Z"^^xsd:dateTime;
-    dct:creator orcid:0000-0002-1267-0234;
-    npx:introduces <https://example.org/ns/~~~ARTIFACTCODE~~~> .
-}
-"""
-
-
-def test_sign_artifactcode_placeholder_in_custom_namespace():
-    """Signing a nanopub that mints a concept in a custom namespace via the
-    ``~~~ARTIFACTCODE~~~`` placeholder gives that concept the same trusty code
-    as the nanopub itself, and the result is valid (see issue #232)."""
-    ds = Dataset()
-    ds.parse(data=ARTIFACTCODE_PLAIN_TRIG, format="trig")
-    np = Nanopub(conf=testsuite_conf, rdf=ds)
-    np.sign()
-
-    assert np.has_valid_signature
-    assert np.has_valid_trusty
-    assert np.is_valid
-
-    artifact_code = str(np.source_uri).removeprefix(NP_PREFIX)
-    assert re.fullmatch(r"RA[A-Za-z0-9\-_]{43}", artifact_code)
-
-    # The placeholder must be gone and the concept must carry the nanopub's code.
-    concept = URIRef(f"https://example.org/ns/{artifact_code}")
-    subjects = {s for s, _, _, _ in np.rdf.quads((None, None, None, None))}
-    objects = {o for _, _, o, _ in np.rdf.quads((None, None, None, None))}
-    assert concept in subjects
-    assert concept in objects  # still referenced by npx:introduces
-    for term in subjects | objects:
-        assert "~~~ARTIFACTCODE~~~" not in str(term)
+from tests.conftest import profile_test
 
 
 class TestVerifyTrusty:


### PR DESCRIPTION
Follow-up to #233, addressing @ashleycaselli's review comments.

## Changes

- **Move the test** `test_sign_artifactcode_placeholder_in_custom_namespace` from `tests/test_sign_utils.py` to the `TestSign` class in `tests/test_nanopub.py`. As noted in review, `test_sign_utils.py` covers `nanopub/sign_utils.py` specifically, while signing-process tests live under `TestSign`.
- **Source the input from the testsuite** via the testsuite connector (`testsuite.get_transform_cases("rsa-key1")` → `artifactcode-1.in.trig`) instead of duplicating the TRIG as an inline string. This reduces redundancy and avoids divergence from the authoritative test data.

The test still adds value beyond `test_testsuite.py::test_testsuite_sign_valid` (which only compares `source_uri`): it specifically asserts that the concept minted in the custom namespace carries the nanopub's trusty code and that the `~~~ARTIFACTCODE~~~` placeholder is gone everywhere.

## Testing

All 425 tests pass (`uv run pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)