### PR TITLE
fix(sign): define old_o before logging replaced object blank node

### DIFF
--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -627,6 +627,7 @@ class Nanopub:
                         bnode_map[str(o)] = self._bnode_count
                     else:
                         bnode_map[str(o)] = str(o)
+                old_o = o
                 o = self._metadata.namespace[f"_{bnode_map[str(o)]}"]
 
                 g.add((s, p, o, c))

--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -530,6 +530,28 @@ class TestSign:
         assert expected_trusty in np.source_uri
         assert np.has_valid_signature
 
+    def test_nanopub_sign_object_bnode(self):
+        """Regression: a blank node in object position must not crash signing.
+
+        ``_replace_blank_nodes`` referenced an undefined ``old_o`` in a debug log
+        on the object branch, which raised ``NameError`` during ``sign()`` (the
+        other ``sign_bnode`` tests only use blank nodes in subject position, so
+        they never exercised this branch). The blank node should be rewritten to
+        a concrete URI in the nanopub's namespace.
+        """
+        ex = Namespace("http://example.org/")
+        assertion = Graph()
+        bnode = BNode("objnode")
+        # bnode appears in object position (first triple) and subject position
+        # (second), mirroring real "introduce a structured value" assertions.
+        assertion.add((ex.subject, ex.hasPart, bnode))
+        assertion.add((bnode, RDF.type, ex.Part))
+        np = Nanopub(conf=default_conf, assertion=assertion)
+        np.sign()
+        assert np.has_valid_signature
+        # The object blank node was replaced by a concrete URI, none remain.
+        assert not any(isinstance(o, BNode) for o in np.rdf.objects())
+
     def test_specific_file(self):
         """Test to sign a complex file with many blank nodes"""
 


### PR DESCRIPTION
## Problem

`Nanopub.sign()` crashes with `NameError: name 'old_o' is not defined` for any nanopublication whose RDF contains a **blank node in object position**.

In `Nanopub._replace_blank_nodes` (`nanopub/nanopub.py`), the object branch logs:

```python
logger.debug("Replaced object BNode %s -> %s (graph=%s, subj=%s, pred=%s)", old_o, o, c, s, p)
```

but `old_o` is never defined (the subject branch has no equivalent log line). Because Python evaluates logging arguments **eagerly**, this raises regardless of the configured log level — so it is a hard crash, not a logging-only issue.

This affects real-world assertions that introduce structured values via blank nodes (e.g. `:term :hasContextAlias [ a :ContextAlias ; ... ]`). The existing `test_nanopub_sign_bnode` / `test_nanopub_sign_bnode2` tests only use blank nodes in **subject** position, so this branch was never exercised.

## Fix

Capture `old_o = o` before reassigning `o` to the namespaced URI, so the debug log reflects the original node. One line, no behaviour change beyond not crashing.

## Test

Adds `test_nanopub_sign_object_bnode`, which signs an assertion with an object-position blank node and asserts the signature is valid and the blank node was rewritten to a concrete URI. Verified it fails with `NameError` before the fix and passes after. Full `-k sign` suite passes (11 passed).
