### PR TITLE
docs: document the Conventional Commits convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,35 @@ The sections below outline the steps in each case.
 1. create the pull request, e.g. following the instructions [here](https://help.github.com/articles/creating-a-pull-request/).
 
 In case you feel like you've made a valuable contribution, but you don't know how to write or run tests for it, or how to generate the documentation: don't let this discourage you from making the pull request; we can help you! Just go ahead and submit the pull request, but keep in mind that you might be asked to append additional commits to your pull request.
+
+## Commit messages
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Each commit message starts with a type, an optional scope, and a short description:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types used here:
+
+- `feat` — a new feature;
+- `fix` — a bug fix;
+- `docs` — documentation only;
+- `test` — adding or correcting tests;
+- `refactor` — a code change that neither fixes a bug nor adds a feature;
+- `chore` — build, tooling, or maintenance changes;
+- `ci` — changes to CI configuration.
+
+Indicate breaking changes with a `!` after the type/scope (e.g. `feat!:`) and/or a `BREAKING CHANGE:` footer. Examples:
+
+```
+fix(sign): define old_o before logging replaced object blank node
+docs: document the Conventional Commits convention
+feat(client)!: drop support for the legacy server URL
+```
+
+Keeping commit messages consistent makes the history easier to read and lets us generate the changelog automatically.


### PR DESCRIPTION
## What

Adds a **Commit messages** section to `CONTRIBUTING.md` documenting that the project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.

The repository's history already largely uses Conventional Commit prefixes (`feat:`, `fix:`, `ci:`, `chore:`, …); this just makes the convention explicit for contributors and supports automated changelog generation.

## Contents

- The `<type>[scope]: <description>` format with body/footer.
- The common types used here (`feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`).
- How to flag breaking changes (`!` and/or `BREAKING CHANGE:`), with examples.

Documentation-only change; no code touched.
