### PR TITLE
fix(profile): accept standard PEM/DER RSA keys on load

### DIFF
--- a/nanopub/__main__.py
+++ b/nanopub/__main__.py
@@ -28,6 +28,7 @@ DEFAULT_PRIVATE_KEY_PATH = USER_CONFIG_DIR / PRIVATE_KEY_FILE
 DEFAULT_PUBLIC_KEY_PATH = USER_CONFIG_DIR / PUBLIC_KEY_FILE
 RSA = 'RSA'
 ORCID_ID_REGEX = r'^https://orcid.org/(\d{4}-){3}\d{3}(\d|X)$'
+PLACEHOLDER_ORCID_ID = 'https://orcid.org/0000-0000-0000-0000'
 
 
 def validate_orcid_id(ctx, param, orcid_id: str):
@@ -65,12 +66,15 @@ def sign(
             None, "--private-key", "-k",
             help="Path to the RSA private key with which the nanopub will be signed."
         ),
+        orcid_id: str = typer.Option(
+            PLACEHOLDER_ORCID_ID, "--orcid", "-o",
+            help="ORCID iD to record as the signer (full URI or bare 0000-0000-0000-0000 form)."
+        ),
 ):
     if private_key:
         config = NanopubConf(
             profile=Profile(
-                # TODO: better handle Profile without name or orcid_id
-                name='', orcid_id='',
+                name='', orcid_id=orcid_id,
                 private_key=private_key
             ),
         )

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -3,7 +3,7 @@ This module holds objects and functions to load a nanopub user profile.
 """
 import logging
 import os
-from base64 import decodebytes
+from base64 import b64encode, decodebytes
 from pathlib import Path
 from typing import Optional, Union
 
@@ -54,33 +54,34 @@ class Profile:
         elif isinstance(private_key, Path):
             try:
                 with open(private_key) as f:
-                    self._private_key = f.read().strip()
+                    raw_private_key = f.read()
             except FileNotFoundError:
                 raise ProfileError(
                     f'Private key file {private_key} for nanopub not found.\n'
                     f'Maybe your nanopub profile was not set up yet or not set up '
                     f'correctly. \n{PROFILE_INSTRUCTIONS_MESSAGE}'
                 )
+            self._private_key = normalize_private_key(raw_private_key)
         else:
-            self._private_key = private_key
+            self._private_key = normalize_private_key(private_key)
 
         if not public_key and private_key:
             logger.info(
                 'The public key was not provided when loading the Nanopub profile, generating it from the provided private key')
-            key = RSA.import_key(decodebytes(self._private_key.encode()))
-            self._public_key = format_key(key.publickey().export_key().decode('utf-8'))
+            self._public_key = normalize_public_key(self._private_key)
         elif isinstance(public_key, Path):
             try:
                 with open(public_key) as f:
-                    self._public_key = f.read().strip()
+                    raw_public_key = f.read()
             except FileNotFoundError:
                 raise ProfileError(
-                    f'Private key file {public_key} for nanopub not found.\n'
+                    f'Public key file {public_key} for nanopub not found.\n'
                     f'Maybe your nanopub profile was not set up yet or not set up '
                     f'correctly. \n{PROFILE_INSTRUCTIONS_MESSAGE}'
                 )
+            self._public_key = normalize_public_key(raw_public_key)
         elif public_key:
-            self._public_key = public_key
+            self._public_key = normalize_public_key(public_key)
 
     def generate_keys(self) -> str:
         """Generate private/public RSA key pair at the path specified in the profile.yml, to be used to sign nanopubs"""
@@ -256,3 +257,56 @@ def format_key(key: str) -> str:
     if key.startswith("-----BEGIN PUBLIC KEY-----"):
         key = key.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "")
     return key.replace("\n", "").strip()
+
+
+def _load_rsa_key(key_data: str) -> RSA.RsaKey:
+    """Parse an RSA key from any standard serialization.
+
+    Accepts PEM (PKCS#1 ``BEGIN RSA PRIVATE KEY`` or PKCS#8 ``BEGIN PRIVATE
+    KEY``), DER, or the bare single-line base64 that nanopub itself stores (DER
+    without the PEM armor), with any line endings. Raises a clear ProfileError
+    instead of letting an opaque base64/parsing error surface from deep inside
+    the crypto library.
+    """
+    key_data = key_data.strip()
+    # RSA.import_key handles PEM (PKCS#1/#8), DER and OpenSSH, and tolerates
+    # surrounding whitespace and CR/LF line endings.
+    try:
+        return RSA.import_key(key_data)
+    except (ValueError, IndexError, TypeError):
+        pass
+    # Fall back to nanopub's own format: bare base64 of the DER, no armor.
+    try:
+        return RSA.import_key(decodebytes(key_data.encode()))
+    except Exception as e:
+        raise ProfileError(
+            'Could not parse the RSA key. Provide a standard PEM or DER RSA key '
+            "(e.g. the output of `openssl genrsa`), or nanopub's base64 key "
+            f'string. If the key is passphrase-protected, decrypt it first.\n'
+            f'Underlying error: {e}\n{PROFILE_INSTRUCTIONS_MESSAGE}'
+        ) from None
+
+
+def normalize_private_key(key_data: str) -> str:
+    """Normalize any RSA private key to nanopub's canonical single-line base64.
+
+    The canonical form is the base64 of the PKCS#8 DER with no PEM armor and no
+    newlines, as required by nanopub-java and assumed by the signing code.
+    """
+    key = _load_rsa_key(key_data)
+    if not key.has_private():
+        raise ProfileError(
+            'A public key was provided where a private key was expected.'
+        )
+    return b64encode(key.export_key(format='DER', pkcs=8)).decode('utf-8')
+
+
+def normalize_public_key(key_data: str) -> str:
+    """Normalize any RSA public key to nanopub's canonical single-line base64.
+
+    The canonical form is the base64 of the SubjectPublicKeyInfo DER with no PEM
+    armor and no newlines. A private key may be passed in, in which case the
+    corresponding public key is derived.
+    """
+    key = _load_rsa_key(key_data)
+    return b64encode(key.publickey().export_key(format='DER')).decode('utf-8')

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -3,6 +3,7 @@ This module holds objects and functions to load a nanopub user profile.
 """
 import logging
 import os
+import re
 import warnings
 from base64 import b64encode, decodebytes
 from pathlib import Path
@@ -27,6 +28,30 @@ class ProfileError(RuntimeError):
     """
 
 
+ORCID_URL_PREFIX = "https://orcid.org/"
+_ORCID_ID_PATTERN = re.compile(r"\d{4}-\d{4}-\d{4}-\d{3}[\dX]")
+
+
+def _normalize_orcid_id(orcid_id: str) -> str:
+    """Validate an ORCID and normalize it to its canonical URI form.
+
+    Accepts either the full ORCID URI (``https://orcid.org/0000-0000-0000-0000``)
+    or the bare identifier (``0000-0000-0000-0000``), always returning the
+    canonical ``https://orcid.org/<id>`` URI. This URI is published verbatim in
+    a nanopub and matched exactly in SPARQL queries, so it must be consistent.
+    Raises ProfileError if no ORCID is provided.
+    """
+    if not orcid_id or not orcid_id.strip():
+        raise ProfileError(
+            "An ORCID iD is required to create a nanopub profile.\n"
+            f"{PROFILE_INSTRUCTIONS_MESSAGE}"
+        )
+    orcid_id = orcid_id.strip()
+    if _ORCID_ID_PATTERN.fullmatch(orcid_id):
+        return f"{ORCID_URL_PREFIX}{orcid_id}"
+    return orcid_id
+
+
 class Profile:
 
     def __init__(
@@ -46,7 +71,7 @@ class Profile:
                 public_key (Optional[Union[Path, str]]): Path to the user's public key, or the key as string
                 introduction_nanopub_uri (Optional[str]): URI of the user's profile nanopub
             """
-        self._orcid_id = orcid_id
+        self.orcid_id = orcid_id
         self._name = name
         self._introduction_nanopub_uri = introduction_nanopub_uri
 
@@ -138,7 +163,7 @@ introduction_nanopub_uri:{intro_uri}
 
     @orcid_id.setter
     def orcid_id(self, value):
-        self._orcid_id = value
+        self._orcid_id = _normalize_orcid_id(value)
 
     @property
     def name(self):

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -3,6 +3,7 @@ This module holds objects and functions to load a nanopub user profile.
 """
 import logging
 import os
+import warnings
 from base64 import b64encode, decodebytes
 from pathlib import Path
 from typing import Optional, Union
@@ -86,11 +87,10 @@ class Profile:
     def generate_keys(self) -> str:
         """Generate private/public RSA key pair at the path specified in the profile.yml, to be used to sign nanopubs"""
         key = RSA.generate(RSA_KEY_SIZE)
-        private_key_str = key.export_key('PEM', pkcs=8).decode('utf-8')
         public_key_str = key.publickey().export_key().decode('utf-8')
 
-        self._private_key = format_key(private_key_str)
-        self._public_key = format_key(public_key_str)
+        self._private_key = _encode_private_key(key)
+        self._public_key = _encode_public_key(key)
         logger.info(f"Public/private RSA key pair has been generated for {self.orcid_id} ({self.name})")
         return public_key_str
 
@@ -230,11 +230,8 @@ def generate_keyfiles(path: Path = USER_CONFIG_DIR) -> str:
         Path(path).mkdir()
 
     key = RSA.generate(RSA_KEY_SIZE)
-    private_key_str = key.export_key('PEM', pkcs=8).decode('utf-8')
-    public_key_str = key.publickey().export_key().decode('utf-8')
-
-    private_key_str = format_key(private_key_str)
-    public_key_str = format_key(public_key_str)
+    private_key_str = _encode_private_key(key)
+    public_key_str = _encode_public_key(key)
     private_path = path / "id_rsa"
     public_path = path / "id_rsa.pub"
 
@@ -250,8 +247,41 @@ def generate_keyfiles(path: Path = USER_CONFIG_DIR) -> str:
     return public_key_str
 
 
+def _encode_private_key(key: RSA.RsaKey) -> str:
+    """Encode an RSA key to nanopub's canonical private-key form.
+
+    The canonical form is the base64 of the PKCS#8 DER with no PEM armor and no
+    newlines, as required by nanopub-java and assumed by the signing code.
+    """
+    return b64encode(key.export_key(format='DER', pkcs=8)).decode('utf-8')
+
+
+def _encode_public_key(key: RSA.RsaKey) -> str:
+    """Encode an RSA key to nanopub's canonical public-key form.
+
+    The canonical form is the base64 of the SubjectPublicKeyInfo DER with no PEM
+    armor and no newlines.
+    """
+    return b64encode(key.publickey().export_key(format='DER')).decode('utf-8')
+
+
 def format_key(key: str) -> str:
-    """Format private and public keys to remove header/footer and all newlines, as this is required by nanopub-java"""
+    """Format private and public keys to remove header/footer and all newlines, as this is required by nanopub-java.
+
+    .. deprecated::
+        ``format_key`` is deprecated and will be removed in an upcoming major
+        version. It only strips PEM armor from a PKCS#8/SPKI key via string
+        replacement and silently mishandles PKCS#1 and CRLF input. Use
+        :func:`normalize_private_key` / :func:`normalize_public_key` instead,
+        which accept any standard PEM/DER/bare key and return the same canonical
+        single-line base64 form.
+    """
+    warnings.warn(
+        "format_key() is deprecated and will be removed in an upcoming major "
+        "version; use normalize_private_key() / normalize_public_key() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if key.startswith("-----BEGIN PRIVATE KEY-----"):
         key = key.replace("-----BEGIN PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "")
     if key.startswith("-----BEGIN PUBLIC KEY-----"):
@@ -298,7 +328,7 @@ def normalize_private_key(key_data: str) -> str:
         raise ProfileError(
             'A public key was provided where a private key was expected.'
         )
-    return b64encode(key.export_key(format='DER', pkcs=8)).decode('utf-8')
+    return _encode_private_key(key)
 
 
 def normalize_public_key(key_data: str) -> str:
@@ -309,4 +339,4 @@ def normalize_public_key(key_data: str) -> str:
     corresponding public key is derived.
     """
     key = _load_rsa_key(key_data)
-    return b64encode(key.publickey().export_key(format='DER')).decode('utf-8')
+    return _encode_public_key(key)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 from nanopub_testsuite_connector import TestSuiteSubfolder
+from rdflib import Dataset, URIRef
 from typer.testing import CliRunner
 
+from nanopub import namespaces
 from nanopub.__main__ import cli, validate_orcid_id
 from nanopub._version import __version__
 from nanopub.definitions import DEFAULT_PROFILE_PATH
@@ -68,6 +70,28 @@ def test_sign_with_key(testsuite):
     ])
     assert result.exit_code == 0
     assert "Nanopub signed in" in result.stdout
+
+
+def test_sign_with_orcid(testsuite, tmp_path):
+    """A bare ORCID passed to --orcid is normalized and recorded as signedBy."""
+    tc = testsuite.get_transform_cases()[0]
+    test_file = tmp_path / "to_sign.trig"
+    test_file.write_text(tc.plain.path.read_text())
+    private_key = str(testsuite.get_signing_key(tc.key_name).private_key)
+
+    result = runner.invoke(cli, [
+        "sign", str(test_file),
+        "-k", private_key,
+        "-o", "1234-5678-1234-5678",
+    ])
+
+    assert result.exit_code == 0
+    signed = tmp_path / "signed.to_sign.trig"
+    assert signed.exists()
+    ds = Dataset()
+    ds.parse(signed, format="trig")
+    signed_by = {o for _, _, o, _ in ds.quads((None, namespaces.NPX.signedBy, None, None))}
+    assert URIRef("https://orcid.org/1234-5678-1234-5678") in signed_by
 
 
 def test_version():

--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -392,6 +392,65 @@ class TestCreationFromTrustyNanopub:
         assert np.get_source_uri_from_graph == "http://purl.org/np/RA1sViVmXf-W2aZW4Qk74KTaiD9gpLBPe2LhMsinHKKz8"
 
 
+class TestProfileKeyFormats:
+    """Loading a Profile from a key file should accept a standard PEM key.
+
+    Regression test for the opaque ``binascii.Error: Incorrect padding`` raised
+    when ``np setup`` (or ``Profile(..., private_key=Path)``) is pointed at a
+    normal PEM private key. The read path at profile.py does ``f.read().strip()``
+    and then ``decodebytes(...)`` without stripping the ``-----BEGIN-----`` armor
+    or newlines, so anything that isn't nanopub's own bare single-line base64
+    blows up deep inside base64 instead of loading or failing with a clear error.
+    """
+
+    @staticmethod
+    def _write_pem(tmp_path, pkcs):
+        """Write a freshly generated RSA key as standard PEM (armor + newlines)."""
+        from Crypto.PublicKey import RSA
+
+        key = RSA.generate(2048)
+        pem = key.export_key("PEM", pkcs=pkcs).decode("utf-8")
+        key_file = tmp_path / "id_rsa"
+        key_file.write_text(pem)
+        return key_file, pem
+
+    def test_standard_pkcs1_pem_key_loads(self, tmp_path):
+        """A PKCS#1 PEM key (-----BEGIN RSA PRIVATE KEY-----) should load."""
+        from nanopub.profile import Profile
+
+        key_file, pem = self._write_pem(tmp_path, pkcs=1)
+        assert pem.startswith("-----BEGIN RSA PRIVATE KEY-----")
+
+        profile = Profile("0000-0000-0000-0000", "Tester", private_key=key_file)
+        assert profile.private_key
+        assert profile.public_key
+
+    def test_standard_pkcs8_pem_key_loads(self, tmp_path):
+        """A PKCS#8 PEM key (-----BEGIN PRIVATE KEY-----) should load."""
+        from nanopub.profile import Profile
+
+        key_file, pem = self._write_pem(tmp_path, pkcs=8)
+        assert pem.startswith("-----BEGIN PRIVATE KEY-----")
+
+        profile = Profile("0000-0000-0000-0000", "Tester", private_key=key_file)
+        assert profile.private_key
+        assert profile.public_key
+
+    def test_crlf_pem_key_loads(self, tmp_path):
+        """A PEM key with Windows CRLF line endings should load."""
+        from nanopub.profile import Profile
+        from Crypto.PublicKey import RSA
+
+        key = RSA.generate(2048)
+        pem = key.export_key("PEM", pkcs=8).decode("utf-8").replace("\n", "\r\n")
+        key_file = tmp_path / "id_rsa"
+        key_file.write_bytes(pem.encode("utf-8"))
+
+        profile = Profile("0000-0000-0000-0000", "Tester", private_key=key_file)
+        assert profile.private_key
+        assert profile.public_key
+
+
 class TestSign:
 
     def test_sign_errors(self, monkeypatch):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -12,71 +12,109 @@ from nanopub.profile import (
 )
 from tests.conftest import profile_test_path, _signing_key
 
-
-def test_instantiate_profile_path():
-    assert isinstance(_signing_key.private_key, Path)
-    assert isinstance(_signing_key.public_key, Path)
-
-    p = Profile(
-        name='Python Tests',
-        orcid_id='https://orcid.org/0000-0000-0000-0000',
-        private_key=_signing_key.private_key,
-        public_key=_signing_key.public_key
-    )
-
-    assert p.orcid_id == 'https://orcid.org/0000-0000-0000-0000'
-    assert p.name == 'Python Tests'
-    assert p.introduction_nanopub_uri is None
-    assert p.private_key == _signing_key.private_key.read_text()
-    assert p.public_key == _signing_key.public_key.read_text()
+ORCID_ID = "https://orcid.org/0000-0000-0000-0000"
 
 
-def test_instantiate_profile_str():
-    private_key_str = _signing_key.private_key.read_text()
-    public_key_str = _signing_key.public_key.read_text()
+class TestProfileInstantiation:
+    _private_key = _signing_key.private_key
+    _public_key = _signing_key.public_key
 
-    assert isinstance(private_key_str, str)
-    assert isinstance(public_key_str, str)
+    _private_key_str = _private_key.read_text()
+    _public_key_str = _public_key.read_text()
 
-    p = Profile(
-        name='Python Tests',
-        orcid_id='https://orcid.org/0000-0000-0000-0000',
-        private_key=private_key_str,
-        public_key=public_key_str
-    )
+    def test_instantiate_profile_with_empty_orcid_id(self):
+        with pytest.raises(ProfileError):
+            Profile(
+                name='Python Tests',
+                orcid_id='',
+                private_key=self._private_key,
+                public_key=self._public_key
+            )
 
-    assert p.orcid_id == 'https://orcid.org/0000-0000-0000-0000'
-    assert p.name == 'Python Tests'
-    assert p.introduction_nanopub_uri is None
-    assert p.private_key == private_key_str
-    assert p.public_key == public_key_str
+    def test_instantiate_profile_with_url_orcid_id(self):
+        p = Profile(
+            name='Python Tests',
+            orcid_id=ORCID_ID,
+            private_key=self._private_key,
+            public_key=self._public_key
+        )
+
+        assert p.orcid_id == ORCID_ID
+
+    def test_instantiate_profile_with_raw_orcid_id(self):
+        p = Profile(
+            name='Python Tests',
+            orcid_id='0000-0000-0000-0000',
+            private_key=self._private_key,
+            public_key=self._public_key
+        )
+
+        assert p.orcid_id == ORCID_ID
+
+    def test_instantiate_profile_path(self):
+        assert isinstance(self._private_key, Path)
+        assert isinstance(self._public_key, Path)
+
+        p = Profile(
+            name='Python Tests',
+            orcid_id=ORCID_ID,
+            private_key=self._private_key,
+            public_key=self._public_key
+        )
+
+        assert p.orcid_id == ORCID_ID
+        assert p.name == 'Python Tests'
+        assert p.introduction_nanopub_uri is None
+        assert p.private_key == self._private_key_str
+        assert p.public_key == self._public_key_str
+
+    def test_instantiate_profile_str(self):
+        assert isinstance(self._private_key_str, str)
+        assert isinstance(self._public_key_str, str)
+
+        p = Profile(
+            name='Python Tests',
+            orcid_id=ORCID_ID,
+            private_key=self._private_key_str,
+            public_key=self._public_key_str
+        )
+
+        assert p.orcid_id == ORCID_ID
+        assert p.name == 'Python Tests'
+        assert p.introduction_nanopub_uri is None
+        assert p.private_key == self._private_key_str
+        assert p.public_key == self._public_key_str
 
 
-def test_load_profile():
-    p = load_profile(profile_test_path)
+class TestProfileLoader:
+    _private_key = _signing_key.private_key
+    _public_key = _signing_key.public_key
 
-    assert p.orcid_id == 'https://orcid.org/0000-0000-0000-0000'
-    assert p.name == 'Python Tests'
-    assert p.introduction_nanopub_uri is None
-    assert p.private_key == _signing_key.private_key.read_text()
-    assert p.public_key == _signing_key.public_key.read_text()
+    _private_key_str = _private_key.read_text()
+    _public_key_str = _public_key.read_text()
 
+    def test_load_profile(self):
+        p = load_profile(profile_test_path)
 
-def test_fail_loading_incomplete_profile(tmpdir):
-    test_file = Path(tmpdir / 'profile.yml')
-    profile_yaml = """orcid_id: https://orcid.org/0000-0000-0000-0000
-name: Python Tests"""
-    with open(test_file, "w") as f:
-        f.write(profile_yaml)
+        assert p.orcid_id == ORCID_ID
+        assert p.name == 'Python Tests'
+        assert p.introduction_nanopub_uri is None
+        assert p.private_key == self._private_key_str
+        assert p.public_key == self._public_key_str
 
-    with pytest.raises(ProfileError):
-        load_profile(test_file)
+    def test_fail_loading_incomplete_profile(self, tmpdir):
+        test_file = Path(tmpdir / 'profile.yml')
+        profile_yaml = f"orcid_id: {ORCID_ID}\nname: Python Tests"
+        with open(test_file, "w") as f:
+            f.write(profile_yaml)
 
+        with pytest.raises(ProfileError):
+            load_profile(test_file)
 
-def test_profile_file_not_found(tmpdir):
-    test_file = Path(tmpdir / 'profile.yml')
-    with pytest.raises(ProfileError):
-        load_profile(test_file)
+    def test_profile_file_not_found(self, tmpdir):
+        test_file = Path(tmpdir / 'profile.yml')
+        with pytest.raises(ProfileError):
+            load_profile(test_file)
 
 
 def test_store_profile(tmpdir):
@@ -84,7 +122,7 @@ def test_store_profile(tmpdir):
 
     p = Profile(
         name='Python Tests',
-        orcid_id='https://orcid.org/0000-0000-0000-0000',
+        orcid_id=ORCID_ID,
         private_key=_signing_key.private_key.read_text(),
         public_key=_signing_key.public_key.read_text()
     )
@@ -95,7 +133,7 @@ def test_store_profile(tmpdir):
     privkey_path = test_folder / "id_rsa"
     with profile_path.open('r') as f:
         assert f.read() == (
-            'orcid_id: https://orcid.org/0000-0000-0000-0000\n'
+            f"orcid_id: {ORCID_ID}\n"
             'name: Python Tests\n'
             f"public_key: {pubkey_path}\n"
             f"private_key: {privkey_path}\n"
@@ -105,7 +143,7 @@ def test_store_profile(tmpdir):
 def test_generate_keys(tmpdir):
     p = Profile(
         name='Python Tests',
-        orcid_id='https://orcid.org/0000-0000-0000-0000',
+        orcid_id=ORCID_ID,
     )
     assert p.private_key is not None
     assert p.public_key is not None
@@ -114,7 +152,7 @@ def test_generate_keys(tmpdir):
 def test_generate_keys_store_profile(tmpdir):
     p = Profile(
         name='Python Tests',
-        orcid_id='https://orcid.org/0000-0000-0000-0000',
+        orcid_id=ORCID_ID,
     )
     assert p.private_key is not None
     assert p.public_key is not None
@@ -127,7 +165,7 @@ def test_generate_keys_store_profile(tmpdir):
     privkey_path = test_folder / "id_rsa"
     with profile_path.open('r') as f:
         assert f.read() == (
-            'orcid_id: https://orcid.org/0000-0000-0000-0000\n'
+            f"orcid_id: {ORCID_ID}\n"
             'name: Python Tests\n'
             f"public_key: {pubkey_path}\n"
             f"private_key: {privkey_path}\n"

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -85,6 +85,25 @@ class TestProfileInstantiation:
         assert p.private_key == self._private_key_str
         assert p.public_key == self._public_key_str
 
+    def test_private_key_path_not_found_raises_profile_error(self, tmp_path):
+        missing = tmp_path / "does_not_exist_id_rsa"
+        with pytest.raises(ProfileError, match="Private key file"):
+            Profile(
+                orcid_id=ORCID_ID,
+                name="Python Tests",
+                private_key=missing,
+            )
+
+    def test_public_key_path_not_found_raises_profile_error(self, tmp_path):
+        missing_public = tmp_path / "does_not_exist_id_rsa.pub"
+        with pytest.raises(ProfileError, match="Public key file"):
+            Profile(
+                orcid_id=ORCID_ID,
+                name="Python Tests",
+                private_key=_signing_key.private_key,
+                public_key=missing_public,
+            )
+
 
 class TestProfileLoader:
     _private_key = _signing_key.private_key

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 import pytest
 
-from nanopub.profile import Profile, ProfileError, format_key, load_profile
+from nanopub.profile import (
+    Profile,
+    ProfileError,
+    format_key,
+    load_profile,
+    normalize_private_key,
+    normalize_public_key,
+)
 from tests.conftest import profile_test_path, _signing_key
 
 TEST_PRIVATE_KEY = 'MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAPdEfIdHtZYoFh6/DWorzoHpFXMjugqW+CGpe9uk4BfUq54MToi2u7fgdGGtXLg4wsJFBYETdVeS0p1uA7EPe8LhwjHPktf5c6AZbO/lYpKM59e7/Ih4mvOy4iTIe/Dv+1OgasTSK0nXAbKUm/5iJ6LOYa82JQeE/QnT5gUw2e97AgMBAAECgYBbNQnyJINYpeSy5qoeFZaQ2Ncup2kCavmQASJMvJ5ka+/51nRJfY30n3iOZxIiad19J1SGbhUEfoXtyBzYfOubF2i2GJtdF5VyjdSoU6w/gOo2/vnbH+GCHnMclrWshohOADGQU/Y8pYhIvlQqcb6xEOts9m9C9g4uwvPXqjmhoQJBAPkmSFIZwF3i2UvJlHyeXi599L0jkGTUJy/Y4IjieUx5suwvAtG47ejhgIPKK06VtW49oGPHWjWc3cJAmnV+vTMCQQD+EPTvNtLpX9QiDEJD7b8woDwmVrvH/RUosP/cXpMQd7BUVgPlpffAlFJGDlOzwwjZjy+8kc6MYevh1kWqobSZAkEAyCs+nV99ErEHnYEFoB1oU3f0oeSpxKhCF4np03AIvi1kV6bpX+9wjNJnevp5UriqvDgc3S0zx7EQ5Vkb/1vkywJBAMMw59y4tAVT+DhITsi9aTvEfzG9RPt6trzSb2Aw0K/AJJpGkyvl/JfZ2/Oyoh/jYXM0DKrFIni76mtRIajcH1ECQQCJi6aXOaRkRPmf7FYY9cRaJdR1BtZkKZbDg6ZMD1bY97cGiM9STTMeldYcCtQBtyhVCTEObI/V6/0FAvY9Zi7w'
@@ -124,6 +131,23 @@ def test_generate_keys_store_profile(tmpdir):
 
     p2 = load_profile(profile_path)
     assert p2.private_key == p.private_key
+
+
+def test_canonical_pubkey_literal_is_stable():
+    """Normalizing an already-canonical key must be a byte-for-byte identity.
+
+    The public key is published verbatim into the nanopub's pubinfo as
+    ``Literal(profile.public_key)`` and matched exactly in SPARQL queries. Any
+    variation in this literal silently breaks exact matching against every
+    previously published nanopub, so normalization must not alter a key that is
+    already in nanopub's canonical bare-base64 form.
+    """
+    # Identity for a public key already in canonical form.
+    assert normalize_public_key(TEST_PUBLIC_KEY) == TEST_PUBLIC_KEY
+    # Identity for a private key already in canonical form (signing determinism).
+    assert normalize_private_key(TEST_PRIVATE_KEY) == TEST_PRIVATE_KEY
+    # Public key derived from the private key yields the same canonical literal.
+    assert normalize_public_key(TEST_PRIVATE_KEY) == TEST_PUBLIC_KEY
 
 
 def test_format_key_is_deprecated():

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from nanopub.profile import Profile, ProfileError, load_profile
+from nanopub.profile import Profile, ProfileError, format_key, load_profile
 from tests.conftest import profile_test_path, _signing_key
 
 TEST_PRIVATE_KEY = 'MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAPdEfIdHtZYoFh6/DWorzoHpFXMjugqW+CGpe9uk4BfUq54MToi2u7fgdGGtXLg4wsJFBYETdVeS0p1uA7EPe8LhwjHPktf5c6AZbO/lYpKM59e7/Ih4mvOy4iTIe/Dv+1OgasTSK0nXAbKUm/5iJ6LOYa82JQeE/QnT5gUw2e97AgMBAAECgYBbNQnyJINYpeSy5qoeFZaQ2Ncup2kCavmQASJMvJ5ka+/51nRJfY30n3iOZxIiad19J1SGbhUEfoXtyBzYfOubF2i2GJtdF5VyjdSoU6w/gOo2/vnbH+GCHnMclrWshohOADGQU/Y8pYhIvlQqcb6xEOts9m9C9g4uwvPXqjmhoQJBAPkmSFIZwF3i2UvJlHyeXi599L0jkGTUJy/Y4IjieUx5suwvAtG47ejhgIPKK06VtW49oGPHWjWc3cJAmnV+vTMCQQD+EPTvNtLpX9QiDEJD7b8woDwmVrvH/RUosP/cXpMQd7BUVgPlpffAlFJGDlOzwwjZjy+8kc6MYevh1kWqobSZAkEAyCs+nV99ErEHnYEFoB1oU3f0oeSpxKhCF4np03AIvi1kV6bpX+9wjNJnevp5UriqvDgc3S0zx7EQ5Vkb/1vkywJBAMMw59y4tAVT+DhITsi9aTvEfzG9RPt6trzSb2Aw0K/AJJpGkyvl/JfZ2/Oyoh/jYXM0DKrFIni76mtRIajcH1ECQQCJi6aXOaRkRPmf7FYY9cRaJdR1BtZkKZbDg6ZMD1bY97cGiM9STTMeldYcCtQBtyhVCTEObI/V6/0FAvY9Zi7w'
@@ -124,3 +124,15 @@ def test_generate_keys_store_profile(tmpdir):
 
     p2 = load_profile(profile_path)
     assert p2.private_key == p.private_key
+
+
+def test_format_key_is_deprecated():
+    """format_key is retained as a deprecated shim; it must warn but still work."""
+    pem = (
+        "-----BEGIN PUBLIC KEY-----\n"
+        f"{TEST_PUBLIC_KEY}\n"
+        "-----END PUBLIC KEY-----\n"
+    )
+    with pytest.warns(DeprecationWarning, match="format_key"):
+        result = format_key(pem)
+    assert result == TEST_PUBLIC_KEY

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -12,11 +12,11 @@ from nanopub.profile import (
 )
 from tests.conftest import profile_test_path, _signing_key
 
-TEST_PRIVATE_KEY = 'MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAPdEfIdHtZYoFh6/DWorzoHpFXMjugqW+CGpe9uk4BfUq54MToi2u7fgdGGtXLg4wsJFBYETdVeS0p1uA7EPe8LhwjHPktf5c6AZbO/lYpKM59e7/Ih4mvOy4iTIe/Dv+1OgasTSK0nXAbKUm/5iJ6LOYa82JQeE/QnT5gUw2e97AgMBAAECgYBbNQnyJINYpeSy5qoeFZaQ2Ncup2kCavmQASJMvJ5ka+/51nRJfY30n3iOZxIiad19J1SGbhUEfoXtyBzYfOubF2i2GJtdF5VyjdSoU6w/gOo2/vnbH+GCHnMclrWshohOADGQU/Y8pYhIvlQqcb6xEOts9m9C9g4uwvPXqjmhoQJBAPkmSFIZwF3i2UvJlHyeXi599L0jkGTUJy/Y4IjieUx5suwvAtG47ejhgIPKK06VtW49oGPHWjWc3cJAmnV+vTMCQQD+EPTvNtLpX9QiDEJD7b8woDwmVrvH/RUosP/cXpMQd7BUVgPlpffAlFJGDlOzwwjZjy+8kc6MYevh1kWqobSZAkEAyCs+nV99ErEHnYEFoB1oU3f0oeSpxKhCF4np03AIvi1kV6bpX+9wjNJnevp5UriqvDgc3S0zx7EQ5Vkb/1vkywJBAMMw59y4tAVT+DhITsi9aTvEfzG9RPt6trzSb2Aw0K/AJJpGkyvl/JfZ2/Oyoh/jYXM0DKrFIni76mtRIajcH1ECQQCJi6aXOaRkRPmf7FYY9cRaJdR1BtZkKZbDg6ZMD1bY97cGiM9STTMeldYcCtQBtyhVCTEObI/V6/0FAvY9Zi7w'
-TEST_PUBLIC_KEY = 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD3RHyHR7WWKBYevw1qK86B6RVzI7oKlvghqXvbpOAX1KueDE6Itru34HRhrVy4OMLCRQWBE3VXktKdbgOxD3vC4cIxz5LX+XOgGWzv5WKSjOfXu/yIeJrzsuIkyHvw7/tToGrE0itJ1wGylJv+YieizmGvNiUHhP0J0+YFMNnvewIDAQAB'
-
 
 def test_instantiate_profile_path():
+    assert isinstance(_signing_key.private_key, Path)
+    assert isinstance(_signing_key.public_key, Path)
+
     p = Profile(
         name='Python Tests',
         orcid_id='https://orcid.org/0000-0000-0000-0000',
@@ -27,25 +27,29 @@ def test_instantiate_profile_path():
     assert p.orcid_id == 'https://orcid.org/0000-0000-0000-0000'
     assert p.name == 'Python Tests'
     assert p.introduction_nanopub_uri is None
-    assert p.private_key == TEST_PRIVATE_KEY
-    assert p.public_key == TEST_PUBLIC_KEY
-    assert p.private_key == TEST_PRIVATE_KEY
-    assert p.public_key == TEST_PUBLIC_KEY
+    assert p.private_key == _signing_key.private_key.read_text()
+    assert p.public_key == _signing_key.public_key.read_text()
 
 
 def test_instantiate_profile_str():
+    private_key_str = _signing_key.private_key.read_text()
+    public_key_str = _signing_key.public_key.read_text()
+
+    assert isinstance(private_key_str, str)
+    assert isinstance(public_key_str, str)
+
     p = Profile(
         name='Python Tests',
         orcid_id='https://orcid.org/0000-0000-0000-0000',
-        private_key=TEST_PRIVATE_KEY,
-        public_key=TEST_PUBLIC_KEY
+        private_key=private_key_str,
+        public_key=public_key_str
     )
 
     assert p.orcid_id == 'https://orcid.org/0000-0000-0000-0000'
     assert p.name == 'Python Tests'
     assert p.introduction_nanopub_uri is None
-    assert p.private_key == TEST_PRIVATE_KEY
-    assert p.public_key == TEST_PUBLIC_KEY
+    assert p.private_key == private_key_str
+    assert p.public_key == public_key_str
 
 
 def test_load_profile():
@@ -54,8 +58,8 @@ def test_load_profile():
     assert p.orcid_id == 'https://orcid.org/0000-0000-0000-0000'
     assert p.name == 'Python Tests'
     assert p.introduction_nanopub_uri is None
-    assert p.private_key == TEST_PRIVATE_KEY
-    assert p.public_key == TEST_PUBLIC_KEY
+    assert p.private_key == _signing_key.private_key.read_text()
+    assert p.public_key == _signing_key.public_key.read_text()
 
 
 def test_fail_loading_incomplete_profile(tmpdir):
@@ -81,8 +85,8 @@ def test_store_profile(tmpdir):
     p = Profile(
         name='Python Tests',
         orcid_id='https://orcid.org/0000-0000-0000-0000',
-        private_key=TEST_PRIVATE_KEY,
-        public_key=TEST_PUBLIC_KEY
+        private_key=_signing_key.private_key.read_text(),
+        public_key=_signing_key.public_key.read_text()
     )
     p.store(test_folder)
 
@@ -143,20 +147,20 @@ def test_canonical_pubkey_literal_is_stable():
     already in nanopub's canonical bare-base64 form.
     """
     # Identity for a public key already in canonical form.
-    assert normalize_public_key(TEST_PUBLIC_KEY) == TEST_PUBLIC_KEY
+    assert normalize_public_key(_signing_key.public_key.read_text()) == _signing_key.public_key.read_text()
     # Identity for a private key already in canonical form (signing determinism).
-    assert normalize_private_key(TEST_PRIVATE_KEY) == TEST_PRIVATE_KEY
+    assert normalize_private_key(_signing_key.private_key.read_text()) == _signing_key.private_key.read_text()
     # Public key derived from the private key yields the same canonical literal.
-    assert normalize_public_key(TEST_PRIVATE_KEY) == TEST_PUBLIC_KEY
+    assert normalize_public_key(_signing_key.private_key.read_text()) == _signing_key.public_key.read_text()
 
 
 def test_format_key_is_deprecated():
     """format_key is retained as a deprecated shim; it must warn but still work."""
     pem = (
         "-----BEGIN PUBLIC KEY-----\n"
-        f"{TEST_PUBLIC_KEY}\n"
+        f"{_signing_key.public_key.read_text()}\n"
         "-----END PUBLIC KEY-----\n"
     )
     with pytest.warns(DeprecationWarning, match="format_key"):
         result = format_key(pem)
-    assert result == TEST_PUBLIC_KEY
+    assert result == _signing_key.public_key.read_text()


### PR DESCRIPTION
Profile / np setup only accepted nanopub's own bare-base64 key format. A standard PEM private key (what openssl/ssh-keygen produce) failed with an opaque `binascii.Error: Incorrect padding`, with no hint at the cause.

This PR fixed that by adding:

 * Normalize any RSA key (PKCS# 1/# 8 PEM, DER, CRLF line endings, or bare base64) through RSA.import_key -> single-line base64
 * Raise a clear ProfileError on unparseable input. 
 * Regression tests for PKCS#1, PKCS#8, and CRLF PEM.
 
Also: 

* Consolidated key encoding behind shared internal helpers (_encode_private_key / _encode_public_key), used by both the generate and load paths so there's a single definition of nanopub's canonical key format. format_key() is now deprecated and will be removed in an upcoming major version. 

