### PR TITLE
Allow signer id to be any URI (agent_id)

### DIFF
--- a/examples/create_and_publish.ipynb
+++ b/examples/create_and_publish.ipynb
@@ -12,13 +12,7 @@
    "cell_type": "markdown",
    "id": "b9b5555b-b43c-4d9f-8d36-33e34c4868d8",
    "metadata": {},
-   "source": [
-    "For the code below to work, you need to have your profile set up, specifying your ORCID identifier and generating a key pair, using this command:\n",
-    "\n",
-    "    $ np setup\n",
-    "\n",
-    "See also: https://nanopublication.github.io/nanopub-py/getting-started/setup/#install-the-nanopub-library"
-   ]
+   "source": "For the code below to work, you need to have your profile set up — an identifier for you or your agent (your ORCID iD, or any other URI) and an RSA key pair — using this command:\n\n    $ np setup\n\nSee also: https://nanopublication.github.io/nanopub-py/getting-started/setup/#install-the-nanopub-library"
   },
   {
    "cell_type": "markdown",
@@ -135,7 +129,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Nanopub URI: \u001B[1mhttps://w3id.org/np/RAEsCWoKbEKujIYmlhhX8OaFg6DRgUt2fgsNiNpK5Ec-s\u001B[0m\n",
+      "Nanopub URI: \u001b[1mhttps://w3id.org/np/RAEsCWoKbEKujIYmlhhX8OaFg6DRgUt2fgsNiNpK5Ec-s\u001b[0m\n",
       "@prefix np: <http://www.nanopub.org/nschema#> .\n",
       "@prefix npx: <http://purl.org/nanopub/x/> .\n",
       "@prefix orcid: <https://orcid.org/> .\n",
@@ -247,7 +241,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Nanopub URI: \u001B[1mhttps://w3id.org/np/RAEsCWoKbEKujIYmlhhX8OaFg6DRgUt2fgsNiNpK5Ec-s\u001B[0m\n",
+      "Nanopub URI: \u001b[1mhttps://w3id.org/np/RAEsCWoKbEKujIYmlhhX8OaFg6DRgUt2fgsNiNpK5Ec-s\u001b[0m\n",
       "@prefix np: <http://www.nanopub.org/nschema#> .\n",
       "@prefix npx: <http://purl.org/nanopub/x/> .\n",
       "@prefix orcid: <https://orcid.org/> .\n",

--- a/nanopub/__main__.py
+++ b/nanopub/__main__.py
@@ -31,15 +31,17 @@ ORCID_ID_REGEX = r'^https://orcid.org/(\d{4}-){3}\d{3}(\d|X)$'
 PLACEHOLDER_ORCID_ID = 'https://orcid.org/0000-0000-0000-0000'
 
 
-def validate_orcid_id(ctx, param, orcid_id: str):
-    """Check if valid ORCID iD, should be https://orcid.org/ + 16 digit in form:
-    https://orcid.org/0000-0000-0000-0000. ctx and param are necessary `click` callback args
+def validate_agent_id(ctx, param, agent_id: str):
+    """Accept any URI as the signer's agent id, taken at face value.
+
+    Only a value that claims to be an ORCID (starts with https://orcid.org/) is
+    format-checked; any other URI is trusted. ctx and param are necessary
+    `click` callback args.
     """
-    if re.match(ORCID_ID_REGEX, orcid_id):
-        return orcid_id
-    else:
-        raise ValueError('Your ORCID iD is not valid, please provide a valid ORCID iD that '
+    if agent_id.startswith('https://orcid.org/') and not re.match(ORCID_ID_REGEX, agent_id):
+        raise ValueError('This looks like an ORCID iD but is not valid; an ORCID iD '
                          'looks like: https://orcid.org/0000-0000-0000-0000')
+    return agent_id
 
 
 @cli.command(help='Get nanopub library version')
@@ -74,7 +76,7 @@ def sign(
     if private_key:
         config = NanopubConf(
             profile=Profile(
-                name='', orcid_id=orcid_id,
+                name='', agent_id=orcid_id,
                 private_key=private_key
             ),
         )
@@ -155,7 +157,7 @@ def setup(
             None,
             help="Your ORCID iD (i.e. https://orcid.org/0000-0000-0000-0000)",
             prompt='What is your ORCID iD (i.e. https://orcid.org/0000-0000-0000-0000)?',
-            callback=validate_orcid_id
+            callback=validate_agent_id
         ),
         name: str = typer.Option(
             None,

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -167,7 +167,7 @@ class Nanopub:
             )
             assertion_attributed_to = self._conf.assertion_attributed_to
             if self._conf.attribute_assertion_to_profile:
-                assertion_attributed_to = URIRef(self.profile.orcid_id)
+                assertion_attributed_to = URIRef(self.profile.agent_id)
             self._handle_assertion_attributed_to(assertion_attributed_to)
             self._handle_publication_attributed_to(
                 self._conf.attribute_publication_to_profile,
@@ -490,7 +490,7 @@ class Nanopub:
                 raise MalformedNanopubError(
                     "No nanopub profile provided, but attribute_publication_to_profile is enabled")
             if publication_attributed_to is None:
-                publication_attributed_to = URIRef(self._profile.orcid_id)
+                publication_attributed_to = URIRef(self._profile.agent_id)
             else:
                 publication_attributed_to = URIRef(publication_attributed_to)
             self._pubinfo.add(

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -32,46 +32,69 @@ ORCID_URL_PREFIX = "https://orcid.org/"
 _ORCID_ID_PATTERN = re.compile(r"\d{4}-\d{4}-\d{4}-\d{3}[\dX]")
 
 
-def _normalize_orcid_id(orcid_id: str) -> str:
-    """Validate an ORCID and normalize it to its canonical URI form.
+def _normalize_agent_id(agent_id: str) -> str:
+    """Validate and normalize the agent id (signer) to a URI.
 
-    Accepts either the full ORCID URI (``https://orcid.org/0000-0000-0000-0000``)
-    or the bare identifier (``0000-0000-0000-0000``), always returning the
-    canonical ``https://orcid.org/<id>`` URI. This URI is published verbatim in
-    a nanopub and matched exactly in SPARQL queries, so it must be consistent.
-    Raises ProfileError if no ORCID is provided.
+    The agent id identifies the signer and may be any URI — a person's ORCID, a
+    different identity provider, or a bot/agent URI. It is taken at face value
+    and never dereferenced. This URI is published verbatim in a nanopub and
+    matched exactly in SPARQL queries, so it must be consistent.
+
+    As a convenience a bare ORCID identifier (``0000-0000-0000-0000``) is
+    expanded to its canonical ``https://orcid.org/`` URI, and any value that
+    claims to be an ORCID (starts with that prefix) must be a well-formed one.
+    Raises ProfileError if no agent id is given, or a claimed ORCID is malformed.
     """
-    if not orcid_id or not orcid_id.strip():
+    if not agent_id or not agent_id.strip():
         raise ProfileError(
-            "An ORCID iD is required to create a nanopub profile.\n"
+            "An agent id (e.g. your ORCID iD) is required to create a nanopub profile.\n"
             f"{PROFILE_INSTRUCTIONS_MESSAGE}"
         )
-    orcid_id = orcid_id.strip()
-    if _ORCID_ID_PATTERN.fullmatch(orcid_id):
-        return f"{ORCID_URL_PREFIX}{orcid_id}"
-    return orcid_id
+    agent_id = agent_id.strip()
+    # Convenience: a bare ORCID identifier -> canonical ORCID URI.
+    if _ORCID_ID_PATTERN.fullmatch(agent_id):
+        return f"{ORCID_URL_PREFIX}{agent_id}"
+    # Only what claims to be an ORCID is format-checked; any other URI is trusted.
+    if agent_id.startswith(ORCID_URL_PREFIX) and not _ORCID_ID_PATTERN.fullmatch(
+            agent_id[len(ORCID_URL_PREFIX):]):
+        raise ProfileError(
+            f"'{agent_id}' looks like an ORCID URI but is not a valid ORCID iD "
+            "(expected https://orcid.org/0000-0000-0000-0000).\n"
+            f"{PROFILE_INSTRUCTIONS_MESSAGE}"
+        )
+    return agent_id
 
 
 class Profile:
 
     def __init__(
             self,
-            orcid_id: str,
-            name: str,
+            agent_id: Optional[str] = None,
+            name: Optional[str] = None,
             private_key: Optional[Union[Path, str]] = None,
             public_key: Optional[Union[Path, str]] = None,
-            introduction_nanopub_uri: Optional[str] = None
+            introduction_nanopub_uri: Optional[str] = None,
+            *,
+            orcid_id: Optional[str] = None,
     ) -> None:
         """Represents a user profile.
 
             Attributes:
-                orcid_id (str): The user's ORCID
+                agent_id (str): URI identifying the signer — an ORCID iD or any other agent URI
                 name (str): The user's name
                 private_key (Optional[Union[Path, str]]): Path to the user's private key, or the key as string
                 public_key (Optional[Union[Path, str]]): Path to the user's public key, or the key as string
                 introduction_nanopub_uri (Optional[str]): URI of the user's profile nanopub
+                orcid_id (str): Deprecated alias for ``agent_id``.
             """
-        self.orcid_id = orcid_id
+        if orcid_id is not None:
+            warnings.warn(
+                "The 'orcid_id' argument is deprecated; use 'agent_id' instead.",
+                DeprecationWarning, stacklevel=2,
+            )
+            if agent_id is None:
+                agent_id = orcid_id
+        self.agent_id = agent_id
         self._name = name
         self._introduction_nanopub_uri = introduction_nanopub_uri
 
@@ -116,7 +139,7 @@ class Profile:
 
         self._private_key = _encode_private_key(key)
         self._public_key = _encode_public_key(key)
-        logger.info(f"Public/private RSA key pair has been generated for {self.orcid_id} ({self.name})")
+        logger.info(f"Public/private RSA key pair has been generated for {self.agent_id} ({self.name})")
         return public_key_str
 
     def store(self, folder: Path = USER_CONFIG_DIR) -> str:
@@ -146,7 +169,7 @@ class Profile:
         if self.introduction_nanopub_uri:
             intro_uri = f" {self.introduction_nanopub_uri}"
         # Store profile.yml
-        profile_yaml = f"""orcid_id: {self.orcid_id}
+        profile_yaml = f"""agent_id: {self.agent_id}
 name: {self.name}
 public_key: {public_key_path}
 private_key: {private_key_path}
@@ -158,12 +181,28 @@ introduction_nanopub_uri:{intro_uri}
         return profile_path
 
     @property
+    def agent_id(self):
+        return self._agent_id
+
+    @agent_id.setter
+    def agent_id(self, value):
+        self._agent_id = _normalize_agent_id(value)
+
+    @property
     def orcid_id(self):
-        return self._orcid_id
+        warnings.warn(
+            "Profile.orcid_id is deprecated; use Profile.agent_id instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        return self._agent_id
 
     @orcid_id.setter
     def orcid_id(self, value):
-        self._orcid_id = _normalize_orcid_id(value)
+        warnings.warn(
+            "Profile.orcid_id is deprecated; use Profile.agent_id instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        self.agent_id = value
 
     @property
     def name(self):
@@ -198,7 +237,7 @@ introduction_nanopub_uri:{intro_uri}
         self._introduction_nanopub_uri = value
 
     def __repr__(self):
-        return f"""\033[1mORCID\033[0m: {self._orcid_id}
+        return f"""\033[1mAgent ID\033[0m: {self._agent_id}
 \033[1mName\033[0m: {self._name}
 \033[1mPrivate key\033[0m: {self._private_key}
 \033[1mPublic key\033[0m: {self._public_key}
@@ -210,15 +249,20 @@ class ProfileLoader(Profile):
 
     def __init__(
             self,
-            orcid_id: str,
             name: str,
             private_key: Path,
             public_key: Optional[Path],
+            agent_id: Optional[str] = None,
+            orcid_id: Optional[str] = None,
             introduction_nanopub_uri: Optional[str] = None
     ) -> None:
-        """Create a ProfileLoader."""
+        """Create a ProfileLoader.
+
+        Both the ``agent_id`` key and the legacy ``orcid_id`` key are accepted
+        from profile.yml; ``agent_id`` takes precedence when both are present.
+        """
         super().__init__(
-            orcid_id=orcid_id,
+            agent_id=agent_id if agent_id is not None else orcid_id,
             name=name,
             private_key=private_key,
             public_key=public_key,

--- a/nanopub/sign_utils.py
+++ b/nanopub/sign_utils.py
@@ -41,7 +41,7 @@ def add_signature(g: Dataset, profile: Profile, dummy_namespace: Namespace, pubi
     g.add((
         dummy_namespace["sig"],
         NPX["signedBy"],
-        URIRef(profile.orcid_id),
+        URIRef(profile.agent_id),
         pubinfo_g,
     ))
     # Normalize RDF

--- a/nanopub/templates/nanopub_claim.py
+++ b/nanopub/templates/nanopub_claim.py
@@ -40,5 +40,5 @@ class NanopubClaim(Nanopub):
         self.assertion.add((this_statement, RDF.type, HYCL.Statement))
         self.assertion.add((this_statement, RDFS.label, Literal(claim)))
 
-        orcid_id_uri = URIRef(self.profile.orcid_id)
+        orcid_id_uri = URIRef(self.profile.agent_id)
         self.provenance.add((orcid_id_uri, HYCL.claims, this_statement))

--- a/nanopub/templates/nanopub_introduction.py
+++ b/nanopub/templates/nanopub_introduction.py
@@ -35,7 +35,7 @@ class NanopubIntroduction(Nanopub):
             raise ProfileError("No profile provided, cannot generate a Nanopub Introduction")
 
         key_declaration = self._metadata.namespace.keyDeclaration
-        orcid_node = URIRef(self.conf.profile.orcid_id)
+        orcid_node = URIRef(self.conf.profile.agent_id)
 
         self.assertion.add((key_declaration, NPX.declaredBy, orcid_node))
         self.assertion.add((key_declaration, NPX.hasAlgorithm, Literal("RSA")))

--- a/nanopub/templates/nanopub_retract.py
+++ b/nanopub/templates/nanopub_retract.py
@@ -44,7 +44,7 @@ class NanopubRetract(Nanopub):
         if not force:
             self._check_public_keys_match(uri)
 
-        orcid_id = self.profile.orcid_id
+        orcid_id = self.profile.agent_id
         self.assertion.add(
             (URIRef(orcid_id), NPX.retracts, URIRef(uri))
         )
@@ -66,7 +66,7 @@ class NanopubRetract(Nanopub):
         if np.metadata.public_key is None:
             raise MalformedNanopubError(f"Public key not found in the nanopub {np.source_uri}")
         if self._conf.profile.public_key is None:
-            raise ValueError(f"Public key not found for profile {self._conf.profile.orcid_id}")
+            raise ValueError(f"Public key not found for profile {self._conf.profile.agent_id}")
         if np.metadata.public_key != self._conf.profile.public_key is None:
             raise AssertionError(
                 "The public key in your profile does not match the public key"

--- a/nanopub/templates/nanopub_update.py
+++ b/nanopub/templates/nanopub_update.py
@@ -76,7 +76,7 @@ class NanopubUpdate(Nanopub):
         if np.metadata.public_key is None:
             raise MalformedNanopubError(f"Public key not found in the nanopub {np.source_uri}")
         if self._conf.profile.public_key is None:
-            raise ValueError(f"Public key not found for profile {self._conf.profile.orcid_id}")
+            raise ValueError(f"Public key not found for profile {self._conf.profile.agent_id}")
         if np.metadata.public_key != self._conf.profile.public_key is None:
             raise AssertionError(
                 "The public key in your profile does not match the public key"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from rdflib import Dataset, URIRef
 from typer.testing import CliRunner
 
 from nanopub import namespaces
-from nanopub.__main__ import cli, validate_orcid_id
+from nanopub.__main__ import cli, validate_agent_id
 from nanopub._version import __version__
 from nanopub.definitions import DEFAULT_PROFILE_PATH
 from nanopub.utils import MalformedNanopubError
@@ -15,20 +15,24 @@ from nanopub.utils import MalformedNanopubError
 runner = CliRunner()
 
 
-def test_validate_orcid_id():
-    valid_ids = ['https://orcid.org/1234-5678-1234-5678',
-                 'https://orcid.org/1234-5678-1234-567X']
-    for orcid_id in valid_ids:
-        assert validate_orcid_id(ctx=None, param=None, orcid_id=orcid_id) == orcid_id
+def test_validate_agent_id():
+    # Any URI is accepted at face value, including non-ORCID identities and bare
+    # ORCID identifiers (expanded later by the Profile).
+    accepted = ['https://orcid.org/1234-5678-1234-5678',
+                'https://orcid.org/1234-5678-1234-567X',
+                'https://other-url.org/1234-5678-1234-5678',
+                'https://example.org/agent/42',
+                '0000-0000-0000-0000']
+    for agent_id in accepted:
+        assert validate_agent_id(ctx=None, param=None, agent_id=agent_id) == agent_id
 
-    invalid_ids = ['https://orcid.org/abcd-efgh-abcd-efgh',
-                   'https://orcid.org/1234-5678-1234-567',
-                   'https://orcid.org/1234-5678-1234-56789',
-                   'https://other-url.org/1234-5678-1234-5678',
-                   '0000-0000-0000-0000']
-    for orcid_id in invalid_ids:
+    # Only values that claim to be an ORCID but are malformed are rejected.
+    invalid_orcids = ['https://orcid.org/abcd-efgh-abcd-efgh',
+                      'https://orcid.org/1234-5678-1234-567',
+                      'https://orcid.org/1234-5678-1234-56789']
+    for agent_id in invalid_orcids:
         with pytest.raises(ValueError):
-            validate_orcid_id(ctx=None, param=None, orcid_id=orcid_id)
+            validate_agent_id(ctx=None, param=None, agent_id=agent_id)
 
 
 def test_setup():

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -152,7 +152,7 @@ def test_store_profile(tmpdir):
     privkey_path = test_folder / "id_rsa"
     with profile_path.open('r') as f:
         assert f.read() == (
-            f"orcid_id: {ORCID_ID}\n"
+            f"agent_id: {ORCID_ID}\n"
             'name: Python Tests\n'
             f"public_key: {pubkey_path}\n"
             f"private_key: {privkey_path}\n"
@@ -184,7 +184,7 @@ def test_generate_keys_store_profile(tmpdir):
     privkey_path = test_folder / "id_rsa"
     with profile_path.open('r') as f:
         assert f.read() == (
-            f"orcid_id: {ORCID_ID}\n"
+            f"agent_id: {ORCID_ID}\n"
             'name: Python Tests\n'
             f"public_key: {pubkey_path}\n"
             f"private_key: {privkey_path}\n"
@@ -209,6 +209,57 @@ def test_canonical_pubkey_literal_is_stable():
     assert normalize_private_key(_signing_key.private_key.read_text()) == _signing_key.private_key.read_text()
     # Public key derived from the private key yields the same canonical literal.
     assert normalize_public_key(_signing_key.private_key.read_text()) == _signing_key.public_key.read_text()
+
+
+class TestAgentId:
+    """The signer id may be any URI (issue #242): taken at face value, with an
+    ORCID-only format check and a deprecated ``orcid_id`` alias for back-compat."""
+
+    _pk = _signing_key.private_key
+    _pub = _signing_key.public_key
+
+    def _profile(self, **kwargs):
+        return Profile(name="Python Tests", private_key=self._pk,
+                       public_key=self._pub, **kwargs)
+
+    def test_accepts_any_uri_at_face_value(self):
+        uri = "https://example.org/agent/42"
+        assert self._profile(agent_id=uri).agent_id == uri
+
+    def test_expands_bare_orcid(self):
+        assert self._profile(agent_id="0000-0000-0000-0000").agent_id == ORCID_ID
+
+    def test_full_orcid_uri_is_kept(self):
+        assert self._profile(agent_id=ORCID_ID).agent_id == ORCID_ID
+
+    def test_rejects_malformed_orcid_uri(self):
+        with pytest.raises(ProfileError):
+            self._profile(agent_id="https://orcid.org/not-an-orcid")
+
+    def test_empty_agent_id_raises(self):
+        with pytest.raises(ProfileError):
+            self._profile(agent_id="")
+
+    def test_orcid_id_kwarg_is_deprecated_alias(self):
+        with pytest.warns(DeprecationWarning, match="orcid_id"):
+            p = self._profile(orcid_id=ORCID_ID)
+        assert p.agent_id == ORCID_ID
+
+    def test_orcid_id_property_is_deprecated_alias(self):
+        p = self._profile(agent_id=ORCID_ID)
+        with pytest.warns(DeprecationWarning, match="orcid_id"):
+            assert p.orcid_id == ORCID_ID
+
+    def test_legacy_orcid_id_yaml_still_loads(self, tmp_path):
+        profile_yml = tmp_path / "profile.yml"
+        profile_yml.write_text(
+            f"orcid_id: {ORCID_ID}\n"
+            "name: Python Tests\n"
+            f"public_key: {self._pub}\n"
+            f"private_key: {self._pk}\n"
+            "introduction_nanopub_uri:\n"
+        )
+        assert load_profile(profile_yml).agent_id == ORCID_ID
 
 
 def test_format_key_is_deprecated():


### PR DESCRIPTION
Closes #242 .

This PR generalizes the ORCID-only signer to a agent_id that accepts any URI at face value (an ORCID, another identity provider, or a bot/agent URI). A bare ORCID (0000-0000-0000-0000) still expands to its canonical URI, and only values claiming to be an ORCID (https://orcid.org/… prefix) are format-checked. We don't do any extra validation (such as verifying that the URI is dereferenceable, etc) in this PR, only basic regex validation.

Backwards-compatible (non-breaking) changes:

* orcid_id kept as a deprecated alias (constructor kwarg + property; warns on the Python API only).
* Legacy orcid_id: key in profile.yml still loads; store() now writes agent_id:.
* CLI setup/sign accept any URI, format-checking only ORCID-shaped values.
* Removal of the deprecated orcid_id is left for a future major.

This PR also adds tests for accepting any URI, bare-ORCID expansion, malformed-ORCID rejection, deprecated alias, and legacy yaml load.