### PR TITLE
fix(fdo): retry transient HTTP failures when resolving FDOs

### DIFF
--- a/nanopub/fdo/retrieve.py
+++ b/nanopub/fdo/retrieve.py
@@ -1,10 +1,9 @@
 from typing import Optional, Union, List
 
-import requests
 from rdflib import RDF, URIRef, Graph
 
 from nanopub import NanopubClient, Nanopub, NanopubConf
-from nanopub.definitions import DEFAULT_HTTP_TIMEOUT
+from nanopub.http_utils import get_session
 from nanopub.fdo import FdoNanopub
 from nanopub.fdo.fdo_record import FdoRecord
 from nanopub.fdo.utils import looks_like_handle
@@ -66,14 +65,14 @@ def resolve_in_nanopub_network(
 
     try:
         # fetch .trig RDF
-        r = requests.get(np_uri + ".trig", allow_redirects=True, timeout=DEFAULT_HTTP_TIMEOUT)
+        r = get_session().get(np_uri + ".trig", allow_redirects=True)
         r.raise_for_status()
 
         content_type = r.headers.get("Content-Type", "").lower()
         if "html" in content_type or r.text.lstrip().startswith("<!DOCTYPE html>"):
             # retry with the effective URL returned by the redirect - this is a dirty workaround for the server somehow returning html when redirecting (strips out the format suffix)
             redirected_url = r.url
-            r = requests.get(redirected_url + ".trig", timeout=DEFAULT_HTTP_TIMEOUT)
+            r = get_session().get(redirected_url + ".trig")
             r.raise_for_status()
 
             np = Nanopub(source_uri=redirected_url)
@@ -104,14 +103,14 @@ def retrieve_content_from_id(iri_or_handle: str) -> Union[bytes, List[bytes]]:
     if isinstance(content_ref, URIRef) or isinstance(content_ref, str):
         if isinstance(content_ref, str):
             content_ref = URIRef(content_ref)
-        response = requests.get(str(content_ref), timeout=DEFAULT_HTTP_TIMEOUT)
+        response = get_session().get(str(content_ref))
         response.raise_for_status()
         return response.content
 
     elif isinstance(content_ref, list):
         contents = []
         for uri in content_ref:
-            response = requests.get(str(uri), timeout=DEFAULT_HTTP_TIMEOUT)
+            response = get_session().get(str(uri))
             response.raise_for_status()
             contents.append(response.content)
         return contents
@@ -122,7 +121,7 @@ def retrieve_content_from_id(iri_or_handle: str) -> Union[bytes, List[bytes]]:
 
 def resolve_handle_metadata(handle: str) -> dict:
     url = f"https://hdl.handle.net/api/handles/{handle}"
-    response = requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT)
+    response = get_session().get(url)
     response.raise_for_status()
     return response.json()
 

--- a/nanopub/http_utils.py
+++ b/nanopub/http_utils.py
@@ -1,0 +1,85 @@
+"""Shared HTTP helpers.
+
+The services nanopub talks to (the Nanopub Query servers, the registry, the
+handle system) intermittently answer with transient errors that succeed on an
+immediate retry. This module provides a requests Session that retries those
+automatically, so callers do not have to.
+"""
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from nanopub.definitions import DEFAULT_HTTP_TIMEOUT
+
+# Statuses that mean "the server, or a proxy in front of it, is having a
+# temporary problem" - the same request may well succeed a moment later.
+# 520-524 are Cloudflare-specific: hdl.handle.net sits behind Cloudflare and
+# intermittently answers 520 ("unknown error") for handles that resolve fine
+# on the next attempt.
+TRANSIENT_STATUS_CODES = (429, 500, 502, 503, 504, 520, 521, 522, 523, 524)
+
+DEFAULT_MAX_RETRIES = 3
+# urllib3 sleeps backoff_factor * (2 ** (attempt - 1)) between attempts, so
+# with 3 retries this waits 0s, 1s and 2s: enough to ride out a blip without
+# stalling a caller for long when the service is genuinely down.
+DEFAULT_BACKOFF_FACTOR = 0.5
+
+
+class _TimeoutHTTPAdapter(HTTPAdapter):
+    """Adapter that applies a default timeout to every request on the session.
+
+    requests has no session-wide timeout setting, and a request without one
+    blocks indefinitely. Retrying makes that worse, since each attempt could
+    hang, so the timeout is enforced here rather than left to each call site.
+    """
+
+    def __init__(self, *args, timeout=DEFAULT_HTTP_TIMEOUT, **kwargs):
+        self._timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, request, **kwargs):
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = self._timeout
+        return super().send(request, **kwargs)
+
+
+def retrying_session(
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+        timeout=DEFAULT_HTTP_TIMEOUT,
+) -> requests.Session:
+    """Build a Session that retries transient failures on idempotent requests.
+
+    Retries cover both transport errors (connection failures, timeouts) and the
+    statuses in TRANSIENT_STATUS_CODES. Only idempotent methods are retried, so
+    a POST - publishing a nanopub, for instance - is never sent twice.
+
+    Once the retries are exhausted the final response is returned as-is rather
+    than raised, leaving the caller's own error handling in charge.
+    """
+    retry = Retry(
+        total=max_retries,
+        connect=max_retries,
+        read=max_retries,
+        status=max_retries,
+        status_forcelist=TRANSIENT_STATUS_CODES,
+        backoff_factor=backoff_factor,
+        allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
+        raise_on_status=False,
+    )
+    adapter = _TimeoutHTTPAdapter(max_retries=retry, timeout=timeout)
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_session: requests.Session = None
+
+
+def get_session() -> requests.Session:
+    """The shared retrying session, created on first use."""
+    global _session
+    if _session is None:
+        _session = retrying_session()
+    return _session

--- a/tests/test_fdo_op_retrieve_integration.py
+++ b/tests/test_fdo_op_retrieve_integration.py
@@ -13,31 +13,45 @@ FDO_NANOPUB_IRI = "https://w3id.org/np/RAsSeIyT03LnZt3QvtwUqIHSCJHWW1YeLkyu66Lg4
 HANDLE_PID_WITH_DATAREF = '21.T11975/7fcfec59-f27e-45a7-a9d1-8c9e0c64b064'
 HANDLE_PID_WITH_MULTIPLE_DATAREFS = '21.T11975/1686b432-dd80-4ec8-b8d7-be7fe1d06318'
 
+# These tests resolve FDOs against live services: the Nanopub Query servers and
+# the handle system (hdl.handle.net). Both return transient errors from time to
+# time - a query that comes back empty makes resolve_id() fall back to the
+# handle API, which then answers e.g. 520 - and that is not a defect in the code
+# under test. Rerun such a failure a couple of times before believing it.
+retry_on_transient_network_error = pytest.mark.flaky(max_runs=3)
 
+
+@retry_on_transient_network_error
 @pytest.mark.network
 def test_resolve_id_with_handle():
     record = resolve_id(HANDLE_PID)
     assert record.get_profile() is not None
 
 
+@retry_on_transient_network_error
 @pytest.mark.network
 def test_retrieve_record_from_id():
     record = retrieve_record_from_id(HANDLE_PID)
     assert record.get_profile() is not None
 
 
+@retry_on_transient_network_error
 @pytest.mark.network
 def test_retrieve_content_from_fdo_nanopub_id():
     content = retrieve_content_from_id(FDO_NANOPUB_IRI)
     assert isinstance(content, bytes)
     assert len(content) > 0
-    
+
+
+@retry_on_transient_network_error
 @pytest.mark.network
 def test_retrieve_content_from_handle():
     content = retrieve_content_from_id(HANDLE_PID_WITH_DATAREF)
     assert isinstance(content, bytes)
     assert len(content) > 0
-    
+
+
+@retry_on_transient_network_error
 @pytest.mark.network
 def test_retrieve_content_from_handle_multiple_datarefs():
     content = retrieve_content_from_id(HANDLE_PID_WITH_MULTIPLE_DATAREFS)
@@ -48,6 +62,7 @@ def test_retrieve_content_from_handle_multiple_datarefs():
         assert len(c) > 0
 
 
+@retry_on_transient_network_error
 @pytest.mark.network
 def test_resolve_handle_metadata():
     result = resolve_handle_metadata(HANDLE_PID)

--- a/tests/test_fdo_op_retrieve_unit.py
+++ b/tests/test_fdo_op_retrieve_unit.py
@@ -43,13 +43,13 @@ def test_retrieve_record_from_id(mock_handle):
     assert record is not None
 
 
-@patch("nanopub.fdo.retrieve.requests.get")
+@patch("nanopub.fdo.retrieve.get_session")
 @patch("nanopub.fdo.retrieve.resolve_id")
-def test_retrieve_content_from_id(mock_resolve_id, mock_requests_get):
+def test_retrieve_content_from_id(mock_resolve_id, mock_get_session):
     mock_response = MagicMock()
     mock_response.content = b"fake content"
     mock_response.raise_for_status = MagicMock()
-    mock_requests_get.return_value = mock_response
+    mock_get_session.return_value.get.return_value = mock_response
 
     mock_record = MagicMock()
     mock_record.get_data_ref.return_value = "https://example.org/file.txt"
@@ -59,12 +59,12 @@ def test_retrieve_content_from_id(mock_resolve_id, mock_requests_get):
     assert content == b"fake content"
 
 
-@patch("nanopub.fdo.retrieve.requests.get")
+@patch("nanopub.fdo.retrieve.get_session")
 def test_resolve_handle_metadata(mock_get):
     mock_response = MagicMock()
     mock_response.json.return_value = {"values": []}
     mock_response.raise_for_status = MagicMock()
-    mock_get.return_value = mock_response
+    mock_get.return_value.get.return_value = mock_response
 
     result = resolve_handle_metadata("21.T11966/abc")
     assert isinstance(result, dict)
@@ -128,7 +128,7 @@ def test_resolve_in_nanopub_network_no_data(mock_query):
     assert result is None
 
 
-@patch("nanopub.fdo.retrieve.requests.get")
+@patch("nanopub.fdo.retrieve.get_session")
 @patch("nanopub.fdo.retrieve.resolve_id")
 def test_retrieve_content_from_id_list_case(mock_resolve_id, mock_get):
     mock_record = MagicMock()
@@ -138,7 +138,7 @@ def test_retrieve_content_from_id_list_case(mock_resolve_id, mock_get):
     ]
     mock_resolve_id.return_value = mock_record
     mock_resp = MagicMock(content=b"abc", raise_for_status=lambda: None)
-    mock_get.return_value = mock_resp
+    mock_get.return_value.get.return_value = mock_resp
     content_list = retrieve_content_from_id("some-id")
     assert content_list == [b"abc", b"abc"]
 
@@ -155,7 +155,7 @@ def test_retrieve_content_from_id_no_data_ref(mock_resolve_id):
 @patch("nanopub.fdo.retrieve.resolve_id")
 def test_retrieve_content_from_id_unexpected_type(mock_resolve_id):
     mock_record = MagicMock()
-    mock_record.get_data_ref.return_value = 12345  
+    mock_record.get_data_ref.return_value = 12345
     mock_resolve_id.return_value = mock_record
     with pytest.raises(TypeError):
         retrieve_content_from_id("id")
@@ -164,7 +164,7 @@ def test_retrieve_content_from_id_unexpected_type(mock_resolve_id):
 def test_get_fdo_uri_from_fdo_record_fallback_subjects():
     g = Graph()
     uri = URIRef("https://example.org/other")
-    g.add((uri, URIRef("p"), URIRef("o"))) 
+    g.add((uri, URIRef("p"), URIRef("o")))
     assert get_fdo_uri_from_fdo_record(g) == uri
 
 

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,0 +1,155 @@
+"""Tests for the retrying HTTP session.
+
+These run against a throwaway HTTP server on localhost rather than mocks, so
+they exercise the real urllib3 retry machinery: the responses, the retried
+methods and the give-up behaviour are all the genuine article.
+"""
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+import requests
+from requests.adapters import HTTPAdapter
+
+from nanopub.definitions import DEFAULT_HTTP_TIMEOUT
+from nanopub.http_utils import (
+    DEFAULT_MAX_RETRIES,
+    TRANSIENT_STATUS_CODES,
+    retrying_session,
+)
+
+
+class _ScriptedHandler(BaseHTTPRequestHandler):
+    """Answers with the statuses queued in the server's `script`, in order."""
+
+    def _respond(self):
+        self.server.requests.append((self.command, self.path))
+        # Drain any request body, or the client sees a connection reset
+        # instead of our response.
+        body_length = int(self.headers.get("Content-Length") or 0)
+        if body_length:
+            self.rfile.read(body_length)
+        if self.server.script:
+            status = self.server.script.pop(0)
+        else:
+            status = 200
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"values": []}')
+
+    do_GET = _respond
+    do_POST = _respond
+
+    def log_message(self, *args):
+        pass  # keep the test output quiet
+
+
+@pytest.fixture
+def scripted_server():
+    """A local server that replays a scripted list of status codes."""
+    server = HTTPServer(("127.0.0.1", 0), _ScriptedHandler)
+    server.script = []
+    server.requests = []
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.shutdown()
+    server.server_close()
+
+
+@pytest.fixture
+def session():
+    # No backoff: these tests care about the retry behaviour, not the waiting.
+    return retrying_session(backoff_factor=0)
+
+
+def _url(server, path="/handle"):
+    host, port = server.server_address
+    return f"http://{host}:{port}{path}"
+
+
+def test_retries_520_then_succeeds(scripted_server, session):
+    """The failure that made the FDO handle test flake: Cloudflare 520."""
+    scripted_server.script = [520, 520]
+
+    response = session.get(_url(scripted_server))
+
+    assert response.status_code == 200
+    assert len(scripted_server.requests) == 3  # two failures, then the success
+
+
+@pytest.mark.parametrize("status", TRANSIENT_STATUS_CODES)
+def test_retries_every_transient_status(scripted_server, session, status):
+    scripted_server.script = [status]
+
+    response = session.get(_url(scripted_server))
+
+    assert response.status_code == 200
+    assert len(scripted_server.requests) == 2
+
+
+def test_does_not_retry_client_errors(scripted_server, session):
+    """A 404 is the server's real answer, so it must not be retried."""
+    scripted_server.script = [404]
+
+    response = session.get(_url(scripted_server))
+
+    assert response.status_code == 404
+    assert len(scripted_server.requests) == 1
+
+
+def test_returns_last_response_when_retries_run_out(scripted_server, session):
+    """Give up with the real response, so callers keep their error handling."""
+    scripted_server.script = [520] * (DEFAULT_MAX_RETRIES + 1)
+
+    response = session.get(_url(scripted_server))
+
+    assert response.status_code == 520
+    assert len(scripted_server.requests) == DEFAULT_MAX_RETRIES + 1
+    with pytest.raises(requests.HTTPError):
+        response.raise_for_status()
+
+
+def test_does_not_retry_post(scripted_server, session):
+    """Publishing must never be resent: a retried POST could publish twice."""
+    scripted_server.script = [503]
+
+    response = session.post(_url(scripted_server), data=b"x")
+
+    assert response.status_code == 503
+    assert len(scripted_server.requests) == 1
+
+
+def test_applies_a_default_timeout(scripted_server, session, monkeypatch):
+    """Every request carries a timeout, even though the caller passed none.
+
+    Recorded on the base adapter, i.e. below the layer that injects it, so this
+    sees what actually goes out on the wire.
+    """
+    sent = {}
+    original_send = HTTPAdapter.send
+
+    def recording_send(self, request, **kwargs):
+        sent["timeout"] = kwargs.get("timeout")
+        return original_send(self, request, **kwargs)
+
+    monkeypatch.setattr(HTTPAdapter, "send", recording_send)
+    session.get(_url(scripted_server))
+
+    assert sent["timeout"] == DEFAULT_HTTP_TIMEOUT
+
+
+def test_caller_timeout_wins(scripted_server, session, monkeypatch):
+    """An explicit timeout is not overridden by the session default."""
+    sent = {}
+    original_send = HTTPAdapter.send
+
+    def recording_send(self, request, **kwargs):
+        sent["timeout"] = kwargs.get("timeout")
+        return original_send(self, request, **kwargs)
+
+    monkeypatch.setattr(HTTPAdapter, "send", recording_send)
+    session.get(_url(scripted_server), timeout=17)
+
+    assert sent["timeout"] == 17


### PR DESCRIPTION
Stacked on #247 — **base is `163-query-server-timeouts`, not `main`**. Merge #247 first; this PR's diff is only the two commits on top of it.

## Problem

`test_retrieve_content_from_handle` failed intermittently in CI. It is not a test-only problem — the same failure hits library users.

Reproduced locally (1 failure in 3–12 runs) and captured:

```
requests.exceptions.HTTPError: 520 Server Error: <none> for url:
https://hdl.handle.net/api/handles/21.T11975/7fcfec59-f27e-45a7-a9d1-8c9e0c64b064
```

The chain:

1. `resolve_id` first tries `resolve_in_nanopub_network`, which queries the Nanopub Query servers. Normally this succeeds and the call finishes in ~1.5s.
2. When that query comes back empty, `resolve_id` falls back to `FdoNanopub.handle_to_nanopub` → `resolve_handle_metadata` → `https://hdl.handle.net/api/handles/...`.
3. hdl.handle.net sits behind Cloudflare and intermittently answers **520** for handles that resolve fine on the next attempt. That surfaced as `ValueError: Could not resolve FDO`.

The failing run took **37.6s** vs ~1.5s for a passing one, confirming a hung request preceded the fallback.

## Changes

**`fix(fdo): retry transient HTTP failures when resolving FDOs`**

New `nanopub/http_utils.py` provides a shared retrying session (`urllib3.Retry` + a timeout-applying adapter):

- Retries `(429, 500, 502, 503, 504, 520, 521, 522, 523, 524)` plus connection errors and timeouts. The 520–524 range is Cloudflare-specific and is exactly what was failing.
- **Only idempotent methods** (`GET`/`HEAD`/`OPTIONS`). POST is excluded deliberately — retrying `publish_graph` could publish a nanopub twice.
- `raise_on_status=False`, so once retries are exhausted the real response is returned and callers' existing `raise_for_status()` handling is unchanged. No new exception types leak to users.
- The timeout is applied at the adapter, because `requests` has no session-wide timeout and retrying an un-timed request compounds a hang. A caller-supplied timeout still wins.
- Backoff 0.5 → waits 0s, 1s, 2s; worst case ~3s before giving up.

All five FDO reads in `nanopub/fdo/retrieve.py` now go through it. Since the session carries the timeout, the explicit `timeout=` arguments added by #247 in this file are removed rather than kept alongside it.

**`test(fdo): rerun the FDO integration tests on transient network errors`**

Retries absorb a brief blip but not a sustained outage or an empty query result, so the live-network tests in `test_fdo_op_retrieve_integration.py` are also marked flaky — as the network tests in `test_client.py` already are. `max_runs=3` rather than the 10 used elsewhere, because a hanging handle API can take tens of seconds per attempt.

## Tests

New `tests/test_http_utils.py` (16 tests) runs against a throwaway localhost HTTP server replaying scripted status codes, so it exercises the real urllib3 retry machinery rather than mocks:

- recovery from two consecutive 520s
- every transient status retried (parametrized)
- 404 **not** retried — it is the server's real answer
- POST **not** retried
- giving up returns the last response, and `raise_for_status()` still raises
- a default timeout is applied, and an explicit one is not overridden

Also verified end-to-end that a `get_session()` call from `retrieve.py` survives two 520s and returns real data on the third attempt.

Three existing unit tests in `test_fdo_op_retrieve_unit.py` patched `nanopub.fdo.retrieve.requests.get`, which no longer exists; they now patch `get_session`. Note the mock wiring changed to `mock.return_value.get.return_value`, since the call is `get_session().get(url)`.

Full suite: 484 passed, 0 failed.

## Note on verification

The retry mechanism is proven by the local-server tests above. The live FDO tests passed 15/15 runs after the change, but **needed zero retries** in that window — the upstream was healthy — so that run shows no regression rather than proving the flake is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)