### PR TITLE
chore(renovate): update configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-      "local>ashleycaselli/renovate-config:node",
+      "local>ashleycaselli/renovate-config:node"
   ],
   "automerge": false,
   "packageRules": [
@@ -11,6 +11,29 @@
         "pyproject.toml"
       ],
       "semanticCommitScope": "core-deps"
+    },
+    {
+      "description": "Updates to the docs and dev dependency groups are not shipped to users, so they should not trigger any release",
+      "matchFileNames": [
+        "pyproject.toml"
+      ],
+      "matchJsonata": [
+        "managerData.depGroup = 'docs'",
+        "managerData.depGroup = 'dev'"
+      ],
+      "semanticCommitType": "build",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Updates to the test dependency group are not shipped to users, so they should not trigger any release",
+      "matchFileNames": [
+        "pyproject.toml"
+      ],
+      "matchJsonata": [
+        "managerData.depGroup = 'test'"
+      ],
+      "semanticCommitType": "test",
+      "semanticCommitScope": "deps"
     },
     {
       "description": "Updates to the dependencies under the package.json file should not trigger any release",


### PR DESCRIPTION
Gives the `pyproject.toml` dependency groups their own commit types, so updates to them no longer trigger a release.

| group | commit |
|---|---|
| `docs` | `build(deps)` |
| `dev` | `build(deps)` |
| `test` | `test(deps)` |
| `project.dependencies` | `chore(core-deps)` — unchanged, still a patch release |

## Why `matchJsonata` and not `matchDepTypes`

Renovate's pep621 manager reports the *same* `depType` (`dependency-groups`) for every PEP 735 group — the group name is not part of it, it goes into `managerData.depGroup` ([schema.ts](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/pep621/schema.ts)). So `matchDepTypes` cannot tell `docs` from `test`. `matchJsonata` evaluates against the full dependency object and can reach that field.

The new rules are placed after the existing `pyproject.toml` → `core-deps` rule so they override it for the three groups only.

## Verification

The JSONata expressions were evaluated against the real `jsonata` package with mock dependency objects:

| dependency | group | matched rule |
|---|---|---|
| mkdocs | docs | `build(deps)` |
| pre-commit | dev | `build(deps)` |
| pytest | test | `test(deps)` |
| rdflib | `project.dependencies` | none → falls through to `chore(core-deps)` |

Cross-checked against the `releaseRules` in `semantic-release-preconfigured-conventional-commits`: only `chore(core-deps)`, `docs`, `revert` and `*!` trigger a release, on top of the `feat`/`fix` defaults. Neither `build` nor `test` matches, so all three groups now produce no release — consistent with the existing `package.json` rule.

## Drive-by

The `extends` array had a trailing comma, making the file invalid strict JSON. Renovate tolerates it (JSON5), but standard JSON parsers do not. Removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
