### PR TITLE
feat: reject grlc query nanopublications whose SPARQL doesn't parse

### DIFF
--- a/docs/publishing/publish-nanopublications.md
+++ b/docs/publishing/publish-nanopublications.md
@@ -218,3 +218,34 @@ np_conf = NanopubConf(
     publication_attributed_to = creator_orcid,
 )
 ```
+
+## grlc queries
+
+A nanopublication cannot be edited after the fact, so a [grlc query](https://w3id.org/kpxl/grlc/) whose
+SPARQL does not parse is broken permanently: it can never run, and the only remedy is publishing a
+corrected version. The SPARQL carried by `https://w3id.org/kpxl/grlc/sparql` is therefore checked
+before the nanopublication is signed, and again before it is published. Nanopublications published
+before this check existed still load and read as before; `is_valid` only warns about them.
+
+Most of these queries are not broken by hand-written syntax errors but by a character picked up on
+the way through a word processor or a web page, which reads as the plain one it replaced, so the
+error names it:
+
+```text
+Invalid SPARQL found in the grlc query of this nanopub: This is not valid SPARQL. The character at
+line 2, column 8 is U+00A0 (NO-BREAK SPACE), which SPARQL doesn't allow there. Characters like this
+one tend to slip in when a query is copied from a word processor or a web page, and replacing them
+with their plain equivalents makes the query valid again. (in graph ...)
+```
+
+The check is available on its own, and the queries a nanopublication carries can be inspected
+without signing anything:
+
+```python
+from nanopub.sparql import is_valid_sparql, sparql_syntax_error
+
+is_valid_sparql("select ?np where { ?np ?p ?o }")  # True
+sparql_syntax_error(query)  # the description above, or None
+
+np.invalid_sparql  # (literal, graph, description) for each broken query the nanopub carries
+```

--- a/nanopub/__main__.py
+++ b/nanopub/__main__.py
@@ -136,6 +136,8 @@ def check(filepath: Path):
         for literal, graph in np.ill_typed_literals:
             print(f"\033[1m⚠️  Ill-typed literal\033[0m {literal.n3()} in graph {graph}: "
                   "strict RDF stores may be missing this nanopub")
+        for _, graph, description in np.invalid_sparql:
+            print(f"\033[1m⚠️  Invalid SPARQL\033[0m in graph {graph}: {description}")
     except MalformedNanopubError as e:
         print(f"\033[1m❌ Invalid nanopub\033[0m: {e}")
 

--- a/nanopub/namespaces.py
+++ b/nanopub/namespaces.py
@@ -32,3 +32,6 @@ FDOF = Namespace("https://w3id.org/fdof/ontology#")
 
 FDOC = Namespace("https://w3id.org/fdoc/o/terms/")
 """FDO Connect namespace"""
+
+KPXL_GRLC = Namespace("https://w3id.org/kpxl/grlc/")
+"""grlc query namespace, whose sparql property carries the query of a grlc query nanopub"""

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -21,11 +21,12 @@ from nanopub.definitions import (
     NANOPUB_FETCH_FORMAT,
     TEST_NANOPUB_REGISTRY_URL,
 )
-from nanopub.namespaces import HYCL, NP, NPX, NTEMPLATE, ORCID, PAV
+from nanopub.namespaces import HYCL, KPXL_GRLC, NP, NPX, NTEMPLATE, ORCID, PAV
 from nanopub.nanopub_conf import NanopubConf
 from nanopub.profile import ProfileError
 from nanopub.serialize import serialize_nanopub_trig
 from nanopub.sign_utils import add_signature, publish_graph, verify_signature, verify_trusty
+from nanopub.sparql import sparql_syntax_error
 from nanopub.utils import MalformedNanopubError, NanopubMetadata, extract_np_metadata
 
 logger = logging.getLogger(__name__)
@@ -229,6 +230,7 @@ class Nanopub:
         if self._metadata.signature:
             raise MalformedNanopubError(f"The nanopub have already been signed: {self.source_uri}")
         self._check_ill_typed_literals()
+        self._check_invalid_sparql()
 
         if self.is_valid:
             logger.info("Signing nanopub %s (quads=%d)", self.source_uri or "<unpublished>",
@@ -251,6 +253,7 @@ class Nanopub:
             if not self.is_valid:
                 raise MalformedNanopubError("The nanopub is not valid, cannot publish it")
             self._check_ill_typed_literals()
+            self._check_invalid_sparql()
 
         publish_graph(self.rdf, use_server=self._conf.use_server)
         logger.info(f'Published {self.source_uri} to {self._conf.use_server}')
@@ -364,6 +367,20 @@ class Nanopub:
             else:
                 self._check_ill_typed_literals()
 
+        # Same for a grlc query whose SPARQL does not parse: it can never run, and a
+        # nanopub cannot be corrected after the fact, so only a new one can fix it.
+        invalid_sparql = self.invalid_sparql
+        if invalid_sparql:
+            if self._metadata.signature or self._metadata.trusty:
+                logger.warning(
+                    "Invalid SPARQL found in %s: %s. This grlc query cannot be run, and "
+                    "the only remedy is publishing a corrected version",
+                    self._source_uri or self._metadata.np_uri,
+                    "; ".join(description for _, _, description in invalid_sparql),
+                )
+            else:
+                self._check_invalid_sparql()
+
         if self._metadata.signature:
             if not self.has_valid_signature:
                 raise MalformedNanopubError("The nanopub is not valid")
@@ -385,6 +402,24 @@ class Nanopub:
             for s, p, o, c in self._rdf.quads((None, None, None, None))
             if isinstance(o, Literal) and o.ill_typed
         ]
+
+    @property
+    def invalid_sparql(self) -> List[Tuple[Literal, URIRef, str]]:
+        """The grlc queries carried by this nanopub whose SPARQL does not parse.
+
+        Returns a list of ``(literal, graph, description)`` triples, empty when the
+        nanopub carries no grlc query or every query it carries parses. Which literal
+        holds a query is knowable from the statement that carries it: the predicate is
+        ``https://w3id.org/kpxl/grlc/sparql``.
+        """
+        found = []
+        for _, _, o, c in self._rdf.quads((None, KPXL_GRLC.sparql, None, None)):
+            if not isinstance(o, Literal):
+                continue
+            description = sparql_syntax_error(str(o))
+            if description:
+                found.append((o, c, description))
+        return found
 
     @property
     def rdf(self) -> Dataset:
@@ -703,6 +738,22 @@ class Nanopub:
             raise MalformedNanopubError(
                 f"\033[1mIll-typed literal(s) found\033[0m: {details}. "
                 "The lexical form of a literal must be valid for its datatype"
+            )
+
+    def _check_invalid_sparql(self) -> None:
+        """Refuses a grlc query whose SPARQL does not parse.
+
+        A nanopub cannot be edited after the fact, so such a query is broken permanently:
+        it can never run, and the only remedy is publishing a corrected version.
+        """
+        invalid = self.invalid_sparql
+        if invalid:
+            details = "; ".join(
+                f"{description} (in graph {c})" for _, c, description in invalid
+            )
+            raise MalformedNanopubError(
+                f"\033[1mInvalid SPARQL found\033[0m in the grlc query of this "
+                f"nanopub: {details}"
             )
 
     def _check_named_graphs(self) -> None:

--- a/nanopub/sparql.py
+++ b/nanopub/sparql.py
@@ -1,0 +1,219 @@
+"""Syntax checking for the SPARQL carried by grlc query nanopublications.
+
+A nanopublication cannot be edited after the fact, so a query whose SPARQL is broken is
+broken permanently: it can never run, and the only remedy is publishing a corrected
+version. These checks run before a nanopublication carrying such a query is signed or
+published.
+
+The queries end up being run by grlc against RDF4J, so what this has to match is what
+RDF4J's parser accepts. rdflib's parser stands in for it: it is already a dependency,
+``prepareQuery`` parses without executing anything, and measured against the grlc queries
+published so far it refuses the same ones, in the same place.
+
+What the parser decides is left to the parser. The scan below only comes in afterwards,
+to say which character a failed parse tripped over, since rdflib reports the position it
+backtracked to rather than the offending character in some cases.
+"""
+import logging
+import re
+import unicodedata
+from functools import lru_cache
+from typing import Optional, Tuple
+
+from pyparsing import ParseBaseException
+from rdflib.plugins.sparql import prepareQuery
+
+logger = logging.getLogger(__name__)
+
+CHARACTER_ADVICE = (
+    "Characters like this one tend to slip in when a query is copied from a word "
+    "processor or a web page, and replacing them with their plain equivalents makes "
+    "the query valid again."
+)
+
+#: The only whitespace the SPARQL grammar allows: WS ::= #x20 | #x9 | #xD | #xA
+_SPARQL_WHITESPACE = " \t\n\r"
+
+#: The non-ASCII characters SPARQL allows outside literals, comments and IRIs:
+#: PN_CHARS_BASE plus the two ranges and one character PN_CHARS adds.
+_SPARQL_NAME_CHARS = re.compile(
+    "[\u00B7\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0300-\u036F"
+    "\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u203F-\u2040"
+    "\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF"
+    "\uFDF0-\uFFFD\U00010000-\U000EFFFF]"
+)
+
+#: IRIREF ::= '<' ([^<>"{}|^`\]-[#x00-#x20])* '>'
+_IRI_FORBIDDEN = '<>"{}|^`\\'
+
+
+def _iri_length(sparql: str, start: int) -> int:
+    """The length of the IRI starting at ``start``, or 0 where that '<' is an operator."""
+    for index in range(start + 1, len(sparql)):
+        character = sparql[index]
+        if character == ">":
+            return index - start + 1
+        if character in _IRI_FORBIDDEN or character <= " ":
+            return 0
+    return 0
+
+
+def _find_disallowed_character(sparql: str) -> Optional[Tuple[str, int, int]]:
+    """Find the first character the SPARQL grammar does not allow where it stands.
+
+    Only code positions are examined: comments, string literals and IRIs may hold any
+    character, and published queries do. What is left is a character that is either
+    outside SPARQL's name characters or a whitespace character other than the four the
+    grammar allows -- a no-break space, say, which reads as an ordinary space to whoever
+    wrote the query but stops the parser on the way to grlc.
+
+    :return: the character with its line and column, or None if there is none
+    """
+    index, line, column = 0, 1, 1
+
+    def skip(count: int) -> None:
+        nonlocal index, line, column
+        for _ in range(count):
+            if index >= len(sparql):
+                return
+            if sparql[index] == "\n":
+                line += 1
+                column = 1
+            else:
+                column += 1
+            index += 1
+
+    while index < len(sparql):
+        character = sparql[index]
+
+        # Comment: runs to the end of the line.
+        if character == "#":
+            end = sparql.find("\n", index)
+            skip((len(sparql) if end == -1 else end) - index)
+            continue
+
+        # Long string literal: runs to the matching triple quote.
+        triple = sparql[index : index + 3]
+        if triple in ("'''", '"""'):
+            end = index + 3
+            while end < len(sparql) and sparql[end : end + 3] != triple:
+                end += 2 if sparql[end] == "\\" else 1
+            skip(min(end + 3, len(sparql)) - index)
+            continue
+
+        # Short string literal: runs to the matching quote, at most to the line end.
+        if character in ("'", '"'):
+            end = index + 1
+            while end < len(sparql) and sparql[end] not in (character, "\n"):
+                end += 2 if sparql[end] == "\\" else 1
+            skip(min(end + 1, len(sparql)) - index)
+            continue
+
+        # IRI, if this '<' opens one rather than being a comparison operator.
+        if character == "<":
+            length = _iri_length(sparql, index)
+            if length:
+                skip(length)
+                continue
+
+        disallowed_whitespace = (
+            character.isspace() and character not in _SPARQL_WHITESPACE
+        )
+        disallowed_name = not character.isascii() and not _SPARQL_NAME_CHARS.match(
+            character
+        )
+        if disallowed_whitespace or disallowed_name:
+            return character, line, column
+
+        skip(1)
+
+    return None
+
+
+def _name_character(character: str) -> str:
+    """Name a character by code point, and by Unicode name where it has one."""
+    code = f"U+{ord(character):04X}"
+    try:
+        return f"{code} ({unicodedata.name(character)})"
+    except ValueError:
+        # Control characters and a few others have no name; the code point is enough
+        # to find and replace them.
+        return code
+
+
+def _describe_character(character: str, line: int, column: int) -> str:
+    return (
+        f"This is not valid SPARQL. The character at line {line}, column {column} is "
+        f"{_name_character(character)}, which SPARQL doesn't allow there. "
+        f"{CHARACTER_ADVICE}"
+    )
+
+
+def _describe_parse_error(sparql: str, error: ParseBaseException) -> str:
+    """Describe where the parser stopped, naming the character where that helps.
+
+    A query is more often broken by a character picked up on the way through a word
+    processor or a web page than by a hand-written syntax error, and such a character
+    reads as the plain one it replaced, so the author has no way of spotting it by eye.
+    An ASCII character is left to the parser's own report, which already shows it.
+    """
+    at_parser_position = error.line[error.col - 1 : error.col]
+    if at_parser_position and not at_parser_position.isascii():
+        return _describe_character(at_parser_position, error.lineno, error.col)
+
+    # rdflib backtracks to the start of the construct it was reading, so the position it
+    # reports is not always the offending character; where it is not, look for one.
+    disallowed = _find_disallowed_character(sparql)
+    if disallowed:
+        return _describe_character(*disallowed)
+
+    # The parser lists everything it would have accepted instead, which runs long and
+    # does not survive being quoted in an error message.
+    expected = " ".join(str(error.msg).split())
+    if len(expected) > 120:
+        expected = f"{expected[:117]}..."
+    return (
+        "This is not valid SPARQL. The SPARQL parser reports: "
+        f"{expected} at line {error.lineno}, column {error.col}."
+    )
+
+
+@lru_cache(maxsize=32)
+def sparql_syntax_error(sparql: Optional[str]) -> Optional[str]:
+    """Describe what keeps a string from being a SPARQL query that grlc can run.
+
+    Results are cached: parsing a query of the size these grlc nanopubs carry takes
+    rdflib a few hundred milliseconds, and signing one asks the same question of the
+    same query more than once, by way of ``is_valid``.
+
+    :param sparql: the query to check
+    :return: a description of the problem, in terms the author of the query can act on,
+        or None if the query is fine (or absent)
+    """
+    if sparql is None:
+        return None
+
+    try:
+        prepareQuery(sparql)
+    except ParseBaseException as error:
+        return _describe_parse_error(sparql, error)
+    except Exception as error:  # noqa: BLE001 - rdflib raises bare exceptions here
+        message = str(error).strip()
+        if message.startswith("Unknown namespace prefix"):
+            return f"This is not valid SPARQL. The SPARQL parser reports: {message}."
+        # What is left are the restrictions rdflib applies while building the algebra,
+        # which RDF4J does not, so whether they are worth refusing is for the endpoint
+        # that runs the query to say, not for the signing step.
+        logger.debug("Ignoring non-syntax complaint about a grlc query: %s", error)
+        return None
+
+    return None
+
+
+def is_valid_sparql(sparql: Optional[str]) -> bool:
+    """Report whether a string is a SPARQL query that grlc can run.
+
+    :param sparql: the query to check; a missing query counts as valid, since that is
+        the absence of a query rather than a broken one
+    """
+    return sparql_syntax_error(sparql) is None

--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -892,3 +892,113 @@ class TestIllTypedLiterals:
                 np.publish()
         mock_publish.assert_not_called()
         assert not np.published
+
+
+class TestInvalidSparql:
+    """A grlc query whose SPARQL does not parse must not be signed or published (see
+    issue #266): a nanopub cannot be edited after the fact, so such a query is broken
+    permanently, and the only remedy is publishing a corrected version. A nanopub that is
+    still plain is therefore invalid, while an already signed one stays readable, since
+    nanopubs carrying broken queries are already out there."""
+
+    BROKEN = "select ?np\nwhere {\u00a0?np ?p ?o }"
+    VALID = "select ?np where { ?np ?p ?o }"
+
+    def _grlc_query(self, sparql: str, conf: Optional[NanopubConf] = None) -> Nanopub:
+        np = _minimal_valid_nanopub(conf=conf)
+        np.assertion.add(
+            (URIRef("http://test/query"), RDF.type, namespaces.KPXL_GRLC["grlc-query"])
+        )
+        np.assertion.add(
+            (URIRef("http://test/query"), namespaces.KPXL_GRLC.sparql, Literal(sparql))
+        )
+        return np
+
+    def test_query_that_parses_is_accepted(self):
+        np = self._grlc_query(self.VALID)
+        assert np.invalid_sparql == []
+        assert np.is_valid
+
+    def test_query_that_does_not_parse_names_the_character(self):
+        np = self._grlc_query(self.BROKEN)
+        invalid = np.invalid_sparql
+
+        assert len(invalid) == 1
+        assert str(invalid[0][1]) == str(np.assertion.identifier)
+        assert "U+00A0 (NO-BREAK SPACE)" in invalid[0][2]
+        with pytest.raises(MalformedNanopubError, match="NO-BREAK SPACE"):
+            np.is_valid
+
+    def test_looks_at_every_graph_not_just_the_assertion(self):
+        np = _minimal_valid_nanopub()
+        np.pubinfo.add(
+            (
+                np._metadata.namespace[""],
+                namespaces.KPXL_GRLC.sparql,
+                Literal(self.BROKEN),
+            )
+        )
+        assert len(np.invalid_sparql) == 1
+
+    def test_ignores_a_nanopub_that_carries_no_grlc_query(self):
+        np = _minimal_valid_nanopub()
+        np.assertion.add(
+            (
+                URIRef("http://test"),
+                URIRef("http://example.org/note"),
+                Literal("not a query at all"),
+            )
+        )
+        assert np.invalid_sparql == []
+        assert np.is_valid
+
+    def test_ignores_the_predicate_when_its_object_is_not_a_literal(self):
+        np = _minimal_valid_nanopub()
+        np.assertion.add(
+            (
+                URIRef("http://test/query"),
+                namespaces.KPXL_GRLC.sparql,
+                URIRef("http://example.org/elsewhere"),
+            )
+        )
+        assert np.invalid_sparql == []
+
+    def test_broken_query_in_signed_nanopub_only_warns(self, caplog):
+        """Such nanopubs are out there and cannot be fixed, so they stay readable."""
+        np = self._grlc_query(self.BROKEN)
+        np._metadata.signature = "dummy-signature"
+        with patch.object(Nanopub, "has_valid_signature", True), \
+                caplog.at_level(logging.WARNING, logger="nanopub.nanopub"):
+            assert np.is_valid
+        assert "NO-BREAK SPACE" in caplog.text
+
+    def test_sign_rejects_a_query_that_does_not_parse(self):
+        np = self._grlc_query(self.BROKEN, conf=default_conf)
+        with pytest.raises(MalformedNanopubError, match="NO-BREAK SPACE"):
+            np.sign()
+        assert np.source_uri is None
+
+    def test_sign_accepts_a_query_that_parses(self):
+        np = self._grlc_query(self.VALID, conf=default_conf)
+        np.sign()
+        assert np.source_uri is not None
+
+    def test_publish_rejects_a_broken_query_signed_before_this_check(self, monkeypatch):
+        np = self._grlc_query(self.VALID, conf=default_conf)
+        np.sign()
+        np.pubinfo.add(
+            (
+                np._metadata.namespace[""],
+                namespaces.KPXL_GRLC.sparql,
+                Literal(self.BROKEN),
+            )
+        )
+        # editing the graph after signing breaks the trusty artefact, which is not what
+        # this test is about
+        monkeypatch.setattr(type(np), "is_valid", property(lambda self: True))
+
+        with patch("nanopub.nanopub.publish_graph") as mock_publish:
+            with pytest.raises(MalformedNanopubError, match="NO-BREAK SPACE"):
+                np.publish()
+        mock_publish.assert_not_called()
+        assert not np.published

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -1,0 +1,118 @@
+"""The SPARQL syntax check that keeps a broken grlc query from being published."""
+from nanopub.sparql import is_valid_sparql, sparql_syntax_error
+
+VALID = "select ?np where { ?np ?p ?o }"
+
+#: A published grlc query, shortened: placeholders and a magic property.
+REAL_GRLC_QUERY = """prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix npa: <http://purl.org/nanopub/admin/>
+prefix search: <http://www.openrdf.org/contrib/lucenesail#>
+
+select ?np ?label where {
+  graph npa:graph {
+    ?np npa:hasValidSignatureForPublicKey ?__pubkey .
+    optional { ?np rdfs:label ?label . }
+  }
+  ?np search:matches [ search:query ?_query ; search:property rdfs:label ] .
+}
+limit 100"""
+
+
+class TestAcceptedQueries:
+    def test_accepts_a_valid_query(self):
+        assert sparql_syntax_error(VALID) is None
+        assert is_valid_sparql(VALID)
+
+    def test_accepts_a_published_grlc_query_with_placeholders(self):
+        assert sparql_syntax_error(REAL_GRLC_QUERY) is None
+
+    def test_accepts_a_values_block(self):
+        query = (
+            'select ?a ?b where { values (?a ?b) { (<http://1> "x") (<http://2> UNDEF) }'
+            " ?a ?p ?b }"
+        )
+        assert sparql_syntax_error(query) is None
+
+    def test_treats_a_missing_query_as_valid(self):
+        assert sparql_syntax_error(None) is None
+        assert is_valid_sparql(None)
+
+    def test_accepts_the_characters_sparql_allows_where_they_stand(self):
+        """Comments, string literals and IRIs may hold any character, and do."""
+        query = (
+            "# a comment with a\u00a0no-break space\n"
+            "select ?x where {\n"
+            '  ?x <http://example.org/a\u00a0b> "quoted “hello”, a\u00a0space" .\n'
+            "}"
+        )
+        assert sparql_syntax_error(query) is None
+
+    def test_accepts_a_non_ascii_letter_in_a_prefixed_name(self):
+        query = "prefix ex: <http://example.org/>\nselect ?x where { ?x ex:café ?o }"
+        assert sparql_syntax_error(query) is None
+
+
+class TestRejectedQueries:
+    def test_rejects_an_empty_query(self):
+        error = sparql_syntax_error("")
+        assert error is not None
+        assert error.startswith("This is not valid SPARQL")
+        assert not is_valid_sparql("")
+
+    def test_rejects_a_hand_written_syntax_error(self):
+        error = sparql_syntax_error("select ?x where { ?x ?p }")
+        assert "This is not valid SPARQL." in error
+        assert "The SPARQL parser reports:" in error
+
+    def test_rejects_a_sparql_update(self):
+        error = sparql_syntax_error("insert data { <http://a> <http://b> <http://c> }")
+        assert error is not None
+
+    def test_rejects_an_undeclared_prefix(self):
+        error = sparql_syntax_error("select ?x where { ?x foo:bar ?o }")
+        assert "Unknown namespace prefix" in error
+
+
+class TestNamedCharacters:
+    """The characters this check mainly exists for read as their plain counterparts, so
+    naming them is the whole fix."""
+
+    def test_names_a_no_break_space(self):
+        error = sparql_syntax_error("select ?x\nwhere {\u00a0?x ?p ?o }")
+
+        assert "U+00A0 (NO-BREAK SPACE)" in error
+        assert "line 2, column 8" in error
+        assert "word processor" in error
+
+    def test_names_a_typographic_quotation_mark(self):
+        """rdflib backtracks to the start of the triples block here, so the position it
+        reports is not the offending character and the scan has to find it."""
+        error = sparql_syntax_error("select ?x where { ?x ?p “hello” }")
+
+        assert "U+201C (LEFT DOUBLE QUOTATION MARK)" in error
+        assert "line 1, column 25" in error
+
+    def test_names_a_zero_width_space(self):
+        error = sparql_syntax_error("select ?x\u200b where { ?x ?p ?o }")
+
+        assert "U+200B (ZERO WIDTH SPACE)" in error
+        assert "line 1, column 10" in error
+
+    def test_counts_the_position_past_a_multi_line_literal(self):
+        query = (
+            "select ?x where {\n"
+            '  ?x ?p """first\n'
+            "second\n"
+            'third""" .\n'
+            "  ?x ?q \u00a0?z .\n"
+            "}"
+        )
+        error = sparql_syntax_error(query)
+
+        assert "line 5, column 9" in error
+
+    def test_leaves_an_ascii_character_to_the_parser(self):
+        error = sparql_syntax_error("select ?x where { ?x ?p ?o } }")
+
+        assert "The SPARQL parser reports:" in error
+        assert "U+" not in error


### PR DESCRIPTION
Closes #266. The Java (Nanopublication/nanopub-java#132) and JS (Nanopublication/nanopub-js#41) clients already do this; this is the Python side of the same gap.

A nanopublication can't be edited after the fact, so a grlc query whose SPARQL doesn't parse is broken permanently: it can never run, and the only remedy is publishing a corrected version. Nothing stopped such a nanopublication from being signed and published — the SPARQL was just a long literal like any other on the way out.

## Which parser, and why no new dependency

The queries are run by grlc against RDF4J, so the check has to match what RDF4J's parser accepts. I measured rdflib's `prepareQuery` against RDF4J 5.3.2's own `SPARQLParser` over **the 1364 grlc queries published so far**:

| | count |
| --- | --- |
| Queries RDF4J refuses, rdflib also refuses | 29 |
| Queries RDF4J accepts, rdflib refused | **0** |
| Queries RDF4J refuses, rdflib accepted | 2 |
| Queries broken by a no-break space, named at RDF4J's exact line and column | **15 / 15** |

The two it lets through are semantic rather than syntactic — an alias reused in a projection, a projection outside the `GROUP BY` — which RDF4J catches while building its algebra. Erring that way is the safe direction: a query that is refused here can never be published, so a false refusal is worse than a rare miss.

Nothing had to be adjusted to reach that. rdflib already refuses an empty query and a SPARQL update, already accepts a duplicate projected column and an `AS` target a subquery also binds, and already refuses a no-break space where RDF4J does — the JS client needed pre-declared prefixes and a tolerance list for all of those.

Two other options were considered and dropped:

- [`sparql-validator`](https://github.com/dacamposol/sparql-validator) is a *semantic* validator: it needs an OWL ontology (SHACL shapes optional) and checks datatypes, ranges, facets and object-property axioms. It answers "will this return anything against this ontology", not "does this parse", and a grlc query has no single ontology to validate against. Alpha, and a new dependency.
- `pyoxigraph` parses about three times faster, but exposes no parse-only API — you have to run the query against an empty `Store` — and its report for the no-break-space case points at the wrong place (`error at 2:16` where the character is at 2:8) with no character in it. Not worth a 6 MB binary wheel for a worse message.

rdflib is already a dependency, `prepareQuery` parses without executing anything, and `unicodedata` names the characters for free.

## Naming the character

Most of these queries are not broken by hand-written syntax errors but by a character picked up on the way through a word processor or a web page, which reads as the plain one it replaced, so the author has no way of spotting it by eye:

```text
Invalid SPARQL found in the grlc query of this nanopub: This is not valid SPARQL. The character at
line 2, column 8 is U+00A0 (NO-BREAK SPACE), which SPARQL doesn't allow there. Characters like this
one tend to slip in when a query is copied from a word processor or a web page, and replacing them
with their plain equivalents makes the query valid again. (in graph ...)
```

rdflib points straight at such a character in most cases. Where it backtracks to the start of the construct it was reading instead — a typographic quote in object position, say — `_find_disallowed_character` looks for the character itself. That scan never decides whether a query is valid, only which character to blame for a parse the parser has already refused, and it leaves comments, string literals and IRIs alone, where SPARQL allows anything.

## Wiring

Follows the ill-typed literals of #249, which have the same shape:

- `Nanopub.invalid_sparql` lists `(literal, graph, description)` for each broken query, across all four graphs;
- `sign()` and `publish()` both refuse one, publishing before any server is contacted;
- `is_valid` refuses a plain nanopublication and only warns about a signed or trusty one, which is immutable and already out there, so it stays readable and verifiable;
- `np check` reports it alongside ill-typed literals.

`sparql_syntax_error` is `lru_cache`d: parsing a query of this size takes rdflib a few hundred milliseconds, and signing asks the same question of the same query more than once by way of `is_valid`.

## Test plan

- [x] `pytest` — 532 passed, 0 failed (508 before, plus 24 new)
- [x] `mypy nanopub/sparql.py` — clean; `isort` — clean on the new files
- [x] Re-ran the 1364-query corpus against RDF4J with the final code: 0 refused that RDF4J accepts, 15/15 no-break-space queries named at RDF4J's own line and column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSAawRfUm4Au1UkejyNKY1
