### PR TITLE
fix: stop the test suite from writing into the developer's ~/.nanopub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,6 @@ jobs:
           uv sync --group test --group dev
           uv add ${{ matrix.rdflib-version }}
 
-      - name: Setup nanopub profile (including RSA keys)
-        run: |
-          uv run np setup --orcid-id https://orcid.org/0000-0000-0000-0001 --no-publish --name test --newkeys
-
       - name: Test with pytest
         run: uv run pytest -v --cov
 

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -148,8 +148,7 @@ class Profile:
 
         # Store keys
         if not os.path.exists(private_key_path):
-            with open(private_key_path, "w") as f:
-                f.write(self.private_key + '\n')
+            _write_private_key(private_key_path, self.private_key + '\n')
         if not os.path.exists(public_key_path):
             with open(public_key_path, "w") as f:
                 f.write(self.public_key)
@@ -294,15 +293,27 @@ def generate_keyfiles(path: Path = USER_CONFIG_DIR) -> str:
     public_path = path / "id_rsa.pub"
 
     # Store key pair
-    private_key_file = open(private_path, "w")
-    private_key_file.write(private_key_str)
-    private_key_file.close()
+    _write_private_key(private_path, private_key_str)
 
     public_key_file = open(public_path, "w")
     public_key_file.write(public_key_str)
     public_key_file.close()
     logger.info(f"Public/private RSA key pair has been generated in {private_path} and {public_path}")
     return public_key_str
+
+
+def _write_private_key(path: Union[Path, str], content: str) -> None:
+    """Write a private key to `path`, readable and writable only by its owner.
+
+    The file is created with mode 600 rather than chmod'ed after the fact, so
+    the key is never briefly world-readable; the chmod that follows covers the
+    case of a file that was already there with wider permissions. On Windows,
+    where POSIX permissions do not apply, both are effectively no-ops.
+    """
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(content)
+    os.chmod(path, 0o600)
 
 
 def _encode_private_key(key: RSA.RsaKey) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 import requests
 from nanopub_testsuite_connector import NanopubTestSuite
 
-from nanopub import NanopubConf, load_profile
+from nanopub import NanopubConf, definitions, load_profile
+from nanopub import __main__ as nanopub_cli
 from nanopub.client import TEST_NANOPUB_QUERY_URL
 
 _suite = NanopubTestSuite.get_latest()
@@ -15,6 +17,37 @@ _signing_key = _suite.get_signing_key("rsa-key1")
 @pytest.fixture(scope="session")
 def testsuite() -> NanopubTestSuite:
     return _suite
+
+
+@pytest.fixture(autouse=True)
+def nanopub_config_dir(monkeypatch, tmp_path) -> Path:
+    """Point the user config dir at a temporary directory, for every test.
+
+    Without this, the `setup` command exercised by `tests/test_cli.py` writes
+    RSA keys and a profile into the developer's own `~/.nanopub`, overwriting
+    the profile that is already there (see issue #269).
+
+    `USER_CONFIG_DIR` and the paths derived from it are computed at import time,
+    in `nanopub.definitions` and again in `nanopub.__main__`, so every one of
+    those names has to be redirected. They are patched without `raising=False`
+    on purpose: if one is ever renamed, the fixture should fail loudly rather
+    than quietly stop isolating the home directory.
+    """
+    config_dir = tmp_path / ".nanopub"
+    config_dir.mkdir()
+
+    for module in (definitions, nanopub_cli):
+        monkeypatch.setattr(module, "USER_CONFIG_DIR", config_dir)
+        monkeypatch.setattr(module, "DEFAULT_PROFILE_PATH", config_dir / "profile.yml")
+    monkeypatch.setattr(nanopub_cli, "DEFAULT_KEYS_PATH_PREFIX", config_dir / "id")
+    monkeypatch.setattr(
+        nanopub_cli, "DEFAULT_PRIVATE_KEY_PATH", config_dir / nanopub_cli.PRIVATE_KEY_FILE
+    )
+    monkeypatch.setattr(
+        nanopub_cli, "DEFAULT_PUBLIC_KEY_PATH", config_dir / nanopub_cli.PUBLIC_KEY_FILE
+    )
+
+    return config_dir
 
 
 def pytest_addoption(parser):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
-from pathlib import Path
+import os
+import stat
 from unittest.mock import MagicMock
 
 import pytest
@@ -9,11 +10,24 @@ from typer.testing import CliRunner
 from nanopub import namespaces
 from nanopub.__main__ import cli
 from nanopub._version import __version__
-from nanopub.definitions import DEFAULT_PROFILE_PATH
-from nanopub.profile import _validate_agent_id, ProfileError
+from nanopub.profile import _validate_agent_id, load_profile, ProfileError
 from nanopub.utils import MalformedNanopubError
+from tests.conftest import profile_test
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def cli_profile(monkeypatch):
+    """Give the CLI commands a profile that is not the developer's own.
+
+    They call `load_profile()` with no argument, and its default path is bound
+    at import time, so the `nanopub_config_dir` fixture does not cover it. Left
+    alone, the tests below read `~/.nanopub/profile.yml` and fail on a machine
+    that has none (see issue #269).
+    """
+    monkeypatch.setattr("nanopub.__main__.load_profile", lambda: profile_test)
+    return profile_test
 
 
 def test_validate_agent_id():
@@ -44,17 +58,40 @@ def test_validate_agent_id():
             _validate_agent_id(agent_id=agent_id)
 
 
-def test_setup():
-    # np setup --orcid-id https://orcid.org/0000-0000-0000-0000 --name "Python test" --newkeys --no-publish
+def test_setup(nanopub_config_dir):
+    """`setup --newkeys` writes a profile and a fresh key pair, and nothing else."""
+    # np setup --orcid-id https://orcid.org/0000-0000-0000-0001 --name "Python test" --newkeys --no-publish
     result = runner.invoke(cli, [
         "setup",
         "--orcid-id", "https://orcid.org/0000-0000-0000-0001",
         "--name", "Python test",
         "--newkeys", "--no-publish"
     ])
-    assert result.exit_code == 1
+    assert result.exit_code == 0
     assert "Setting up nanopub profile" in result.stdout
-    assert Path(DEFAULT_PROFILE_PATH).exists()
+
+    private_key = nanopub_config_dir / "id_rsa"
+    assert (nanopub_config_dir / "profile.yml").exists()
+    assert private_key.exists()
+    assert (nanopub_config_dir / "id_rsa.pub").exists()
+
+    profile = load_profile(nanopub_config_dir / "profile.yml")
+    assert profile.agent_id == "https://orcid.org/0000-0000-0000-0001"
+    assert profile.name == "Python test"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file permissions do not apply on Windows")
+def test_setup_private_key_is_not_world_readable(nanopub_config_dir):
+    """The generated private key is readable only by its owner."""
+    runner.invoke(cli, [
+        "setup",
+        "--orcid-id", "https://orcid.org/0000-0000-0000-0001",
+        "--name", "Python test",
+        "--newkeys", "--no-publish"
+    ])
+
+    mode = stat.S_IMODE((nanopub_config_dir / "id_rsa").stat().st_mode)
+    assert mode == 0o600
 
 
 def test_profile():
@@ -113,33 +150,29 @@ def test_version():
     assert __version__ == result.stdout.strip()
 
 
-def test_setup_with_keypair(monkeypatch, tmp_path):
-    monkeypatch.setattr("nanopub.__main__._rsa_keys_exist", lambda: False)
-    monkeypatch.setattr("nanopub.__main__.generate_keyfiles", lambda path: None)
+def test_setup_with_keypair(monkeypatch, testsuite, nanopub_config_dir):
+    """`setup --keypair` copies the given key pair into the config dir and uses it."""
     mock_np = MagicMock()
     monkeypatch.setattr("nanopub.__main__.NanopubIntroduction", lambda **kw: mock_np)
 
-    pub_key = tmp_path / "pub.pem"
-    priv_key = tmp_path / "priv.pem"
-    pub_key.write_text("pub")
-    priv_key.write_text("priv")
+    signing_key = testsuite.get_signing_key("rsa-key1")
 
     result = runner.invoke(cli, [
         "setup",
         "--orcid-id", "https://orcid.org/0000-0000-0000-0001",
         "--name", "Python test",
-        "--keypair", str(pub_key), str(priv_key),
+        "--keypair", str(signing_key.public_key), str(signing_key.private_key),
         "--no-publish"
     ])
     assert "Introduction Nanopub signed but not published" in result.output
     mock_np.sign.assert_called_once()
     mock_np.publish.assert_not_called()
 
+    assert (nanopub_config_dir / "id_rsa").read_text() == signing_key.private_key.read_text()
+    assert (nanopub_config_dir / "id_rsa.pub").read_text() == signing_key.public_key.read_text()
+
 
 def test_setup_publish_yes(monkeypatch):
-    monkeypatch.setattr("nanopub.__main__._rsa_keys_exist", lambda: False)
-    monkeypatch.setattr("nanopub.__main__.generate_keyfiles", lambda path: None)
-
     monkeypatch.setattr("typer.prompt", lambda prompt, type=str, default=None: "y")
 
     mock_np = MagicMock()
@@ -157,9 +190,6 @@ def test_setup_publish_yes(monkeypatch):
 
 
 def test_setup_publish_no(monkeypatch):
-    monkeypatch.setattr("nanopub.__main__._rsa_keys_exist", lambda: False)
-    monkeypatch.setattr("nanopub.__main__.generate_keyfiles", lambda path: None)
-
     monkeypatch.setattr("typer.prompt", lambda prompt, type=str, default=None: "n")
 
     mock_np = MagicMock()


### PR DESCRIPTION
Closes #269.

## What was wrong

`tests/test_cli.py` invoked the real `setup` command without isolating `$HOME`. On a machine that already has a profile, running the suite overwrote `~/.nanopub/profile.yml` with the test's own `agent_id` and `name`; on a machine with none, it wrote real RSA keys — mode `644` — or, via `--keypair`, 3- and 4-byte stub files where the keys belong, which then satisfy `_rsa_keys_exist()` and make a later real `np setup` refuse to run.

## The fix

An autouse `nanopub_config_dir` fixture in `tests/conftest.py` points the user config dir at a temporary directory. `USER_CONFIG_DIR` and the paths derived from it are computed at import time, in `nanopub.definitions` and again in `nanopub.__main__`, so every one of those names is redirected. They are patched *without* `raising=False`, so a future rename fails the fixture loudly rather than quietly stopping the isolation.

A second fixture, `cli_profile` in `tests/test_cli.py`, covers the other direction: the CLI commands call `load_profile()` with no argument, and its default path is bound at import time, so patching the modules does not reach it. Without this the suite still *reads* — and requires — the developer's own `~/.nanopub/profile.yml`.

With the paths isolated, the setup tests assert what they actually mean:

- `test_setup` asserted `exit_code == 1`, i.e. it depended on the machine already having keys. It now asserts `exit_code == 0` and checks that the profile and key pair land in the isolated dir, with the right `agent_id` and `name`.
- `test_setup_with_keypair` used two files containing the strings `pub` and `priv`; it now uses a real key pair from the test suite, since the copy really happens, and checks that both files arrive.
- `test_setup_publish_yes` / `_no` no longer stub out `generate_keyfiles` and `_rsa_keys_exist` — the real key generation runs, in the isolated dir.
- New `test_setup_private_key_is_not_world_readable` (skipped on Windows).

Private keys are now written mode `600` rather than `644`, via a `_write_private_key` helper used by both `generate_keyfiles` and `Profile.store`. The file is created with that mode rather than chmod'ed afterwards, so it is never briefly world-readable.

## Beyond the letter of the issue

Two things the issue did not ask for, called out for review:

1. **The `cli_profile` fixture.** The issue covers writes; this covers the matching read-side dependency. Without it, `HOME=$(mktemp -d) pytest tests/test_cli.py` leaves the home clean but six tests fail for want of a profile.
2. **Dropping the `np setup` step from `.github/workflows/test.yml`.** It existed only to give those tests a profile in CI's throwaway home. Nothing needs it now, and removing it means CI exercises the isolation instead of masking it. Happy to put it back if you would rather keep it.

## Verification

```
# a machine that has never run `np setup`
HOME=$(mktemp -d) .venv/bin/python -m pytest -q
# 11 failed, 486 passed, 12 skipped     <- all 11 are network-blocked in this sandbox
ls -a $HOME                             # .  ..    — nothing written
```

The same 11 failures occur on a clean `origin/main` worktree in this environment (`registry` hosts and `hdl.handle.net` are unreachable here), with 485 passed — the extra pass is the new permissions test. On a machine with a real profile, `~/.nanopub/profile.yml`'s mtime is unchanged across a full run, where before it was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxjxDyQZbG9psNXQpQC8TY